### PR TITLE
Two stage qsub submission

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,8 @@ install:
     - travis_retry pip install pylint yamllint pytest-cov pep8 GDAL==1.10.0 coveralls
     # Dask.array seems to need this?
     - travis_retry pip install cloudpickle
+    - travis_retry pip install git+git://github.com/GeoscienceAustralia/eo-datasets.git
+    - travis_retry pip install git+git://github.com/GeoscienceAustralia/digitalearthau.git
     - travis_retry pip install -e .
 
 script:

--- a/config/ls8_fc_albers.yaml
+++ b/config/ls8_fc_albers.yaml
@@ -11,22 +11,22 @@ partial_ncml_path_template: 'LS8_OLI_FC/{tile_index[0]}_{tile_index[1]}/LS8_OLI_
 ncml_path_template: 'LS8_OLI_FC/LS8_OLI_FC_3577_{tile_index[0]}_{tile_index[1]}.ncml'
 
 sensor_regression_coefficients:
-  blue: |
+  blue:
     - 0.00041
     - 0.97470
-  green: |
+  green:
     - 0.00289
     - 0.99779
-  red: |
+  red:
     - 0.00274
     - 1.00446
-  nir: |
+  nir:
     - 0.00004
     - 0.98906
-  swir1: |
+  swir1:
     - 0.00256
     - 0.99467
-  swir2: |
+  swir2:
     - -0.00327
     - 1.02551
 
@@ -84,7 +84,7 @@ global_attributes:
   product_suite: Fractional Cover 25m
   acknowledgment: |
     Landsat data is provided by the United States Geological Survey (USGS) through direct reception of the data at Geoscience Australias satellite reception facility or download.
-    
+
     The fractional cover algorithm was developed by the Joint Remote Sensing Research Program (JRSRP) and is
     described in Scarth et al. (2010). While originally calibrated in Queensland, a large collaborative effort
     between The Department of Agriculture & ABARES and State and Territory governments to collect additional

--- a/fc/fc_app.py
+++ b/fc/fc_app.py
@@ -19,7 +19,7 @@ from datacube.storage.storage import write_dataset_to_netcdf
 from datacube.ui import click as ui
 from datacube.ui import task_app
 from datacube.utils import unsqueeze_dataset
-from datacube_stats.cli.qsub import QSubLauncher
+from datacube_stats.cli.qsub import QSubLauncher, with_qsub_runner
 from fc.fractional_cover import fractional_cover
 
 _LOG = logging.getLogger('agdc-fc')
@@ -205,6 +205,18 @@ def qsub_generate_tasks_and_run(index, app_config, project, output_tasks_file, t
 
     qsub = QSubLauncher({'-P': project, 'mem': '10gb', 'ncpus': 1, 'walltime': '05:00:00'})
     qsub('run', '--load-tasks', output_tasks_file)
+
+
+
+# Maybe this should just use the existing task_app stuff, but it means we need to go back to the
+# launcher script which needs and environment.sh file and, yeargh
+# It's almost certainly nicer to do the processing using Kirril's `runner`
+@cli.command()
+@task_app.load_tasks_option
+@with_qsub_runner()
+def process_tasks(queue_size, input_tasks_file, runner):
+    pass
+
 
 
 @cli.command(name=APP_NAME)

--- a/fc/fc_app.py
+++ b/fc/fc_app.py
@@ -176,8 +176,7 @@ ROOT_DIR = Path(__file__).absolute().parent.parent
 CONFIG_DIR = ROOT_DIR / 'config'
 SCRIPT_DIR = ROOT_DIR / 'scripts'
 
-
-tag_option = click.option('--tag', type=str, default='notset', help='Unique id for the job')
+tag_option = click.option('--tag', type=str, default='notset', help='Unique id for the job')  # pylint: disable=invalid-name
 
 
 @click.group(help='Datacube Fractional Cover')

--- a/fc/fc_app.py
+++ b/fc/fc_app.py
@@ -3,7 +3,6 @@ from __future__ import absolute_import, print_function
 import errno
 import logging
 import os
-import time
 from copy import deepcopy
 from functools import partial
 from time import time as time_now
@@ -84,14 +83,14 @@ def get_filename(config, tile_index, sources):
                                      version=config['task_timestamp'])
 
 
-def make_fc_tasks(index, config, time=None, **kwargs):
+def make_fc_tasks(index, config, time_range=None, **kwargs):
     input_type = config['nbar_dataset_type']
     output_type = config['fc_dataset_type']
 
     workflow = GridWorkflow(index, output_type.grid_spec)
 
-    tiles_in = workflow.list_tiles(product=input_type.name, time=time)
-    tiles_out = workflow.list_tiles(product=output_type.name, time=time)
+    tiles_in = workflow.list_tiles(product=input_type.name, time=time_range)
+    tiles_out = workflow.list_tiles(product=output_type.name, time=time_range)
 
     def make_task(tile, **task_kwargs):
         task = dict(nbar=workflow.update_tile_lineage(tile))
@@ -193,11 +192,11 @@ def list_configs():
 @click.option('--project', '-P', default='u46')
 @click.option('--queue', '-q', default='normal',
               type=click.Choice(['normal', 'express']))
-@click.option('--year', 'time', callback=task_app.validate_year, help='Limit the process to a particular year')
+@click.option('--year', 'time_range', callback=task_app.validate_year, help='Limit the process to a particular year')
 @task_app.task_app_options
 @ui.pass_index(app_name=APP_NAME)
-def qsub_generate_tasks_and_run(index, app_config, project, output_tasks_file, time):
-    config, tasks = task_app.load_config(index, app_config, make_fc_config, make_fc_tasks, time=time)
+def qsub_generate_tasks_and_run(index, app_config, project, output_tasks_file, time_range):
+    config, tasks = task_app.load_config(index, app_config, make_fc_config, make_fc_tasks, time_range=time_range)
 
     num_tasks_saved = task_app.save_tasks(config, tasks, output_tasks_file)
 

--- a/lambda.md
+++ b/lambda.md
@@ -1,4 +1,3 @@
-
 # The plan for running jobs from AWS Lambda
 
 Required arguments passed Lambda:
@@ -11,14 +10,21 @@ Required arguments passed Lambda:
 
 
 ## Lambda executes this script on `raijin`
+
 The result of which is submitting a PBS job to generate tasks and then
 queue the execution of them.
 ```
 module use /g/data/v10/public/modules/modulefiles
 module load agdc-py3-prod
 module load agdc-fc
+
 cd ${PROCESSING_DIR}
-datacube-fc qsub-task-generation —project ${PROJECT} —app-config ${APP_CONFIG} —year ${YEAR} —save-tasks <task-file-name>
+datacube-fc submit \
+  —-project ${PROJECT} \
+  --tag ${tag} \
+  —-app-config ${APP_CONFIG} \
+  —-year ${YEAR} \
+  —-save-tasks <path-to-task-file>
 ```
 
 The above generates a PBS job which calls the following:
@@ -30,14 +36,20 @@ The above generates a PBS job which calls the following:
 3. **Queues** a PBS job of the right size to process the task
 
 The job doesn't exist as a script, but if it did it would look like:
+
 ```
 module use /g/data/v10/public/modules/modulefiles
 module load agdc-py3-prod
 module load agdc-fc
 
-datacube-fc initiate-batch-processsing <app-config> <year> <processing-dir>
+datacube-fc generate \
+   -v -v \
+   --project <projetc> \
+   --tag <tag> \
+   --app-config <app-config> \
+   --year <year> \
+   --save-tasks <path-to-taskfile>
 ```
-
 
 
 ## PBS Job for Processing Fractional Cover tasks
@@ -49,11 +61,16 @@ module use /g/data/v10/public/modules/modulefiles
 module load agdc-py3-prod
 module load agdc-fc
 
-datacube-fc process-tasks <path-to-taskfile>
+datacube-fc run \
+   -v -v \
+   --tag <tag> \
+   --celery pbs-launch \
+   --load-tasks <path-to-taskfile>
 ```
-
 
 
 ## Extra command for running manually
 
-`datacube-fc run-fc <app-config>`
+Not done currently, but you can generate task list without kicking off qsub with
+`--no-qsub` option for `generate` sub-command, then use `run` sub-command
+without `--celery`, or with `--parallel 4` instead of `--celery`.

--- a/lambda.md
+++ b/lambda.md
@@ -1,0 +1,59 @@
+
+# The plan for running jobs from AWS Lambda
+
+Required arguments passed Lambda:
+
+* **Year** _or range or years_
+* **Project** Such as `v10`/`u46`
+* **FC config** _defines which product to process_
+* **Environment** _which module/environment to run in_
+* **processing-dir**: Output directory for logs and `task-files`. Will be of the form `/g/data/v10/work/fc/<prod_name>/<submission-time>`
+
+
+## Lambda executes this script on `raijin`
+The result of which is submitting a PBS job to generate tasks and then
+queue the execution of them.
+```
+module use /g/data/v10/public/modules/modulefiles
+module load agdc-py3-prod
+module load agdc-fc
+cd ${PROCESSING_DIR}
+datacube-fc qsub-task-generation —project ${PROJECT} —app-config ${APP_CONFIG} —year ${YEAR} —save-tasks <task-file-name>
+```
+
+The above generates a PBS job which calls the following:
+
+## PBS Job for Task Generation of Queueing of Processing
+
+1. **Generates tasks** into `<path-to-taskfile>`
+2. **Calculates required job size** to process these tasks (nodes/ram/time)
+3. **Queues** a PBS job of the right size to process the task
+
+The job doesn't exist as a script, but if it did it would look like:
+```
+module use /g/data/v10/public/modules/modulefiles
+module load agdc-py3-prod
+module load agdc-fc
+
+datacube-fc initiate-batch-processsing <app-config> <year> <processing-dir>
+```
+
+
+
+## PBS Job for Processing Fractional Cover tasks
+
+Again, doesn't exist as a script on disk, but if it did, it would look like:
+
+```
+module use /g/data/v10/public/modules/modulefiles
+module load agdc-py3-prod
+module load agdc-fc
+
+datacube-fc process-tasks <path-to-taskfile>
+```
+
+
+
+## Extra command for running manually
+
+`datacube-fc run-fc <app-config>`

--- a/scripts/datacube-fc-launcher
+++ b/scripts/datacube-fc-launcher
@@ -5,6 +5,7 @@ from __future__ import print_function
 import subprocess
 import click
 from pathlib import Path
+from datacube.ui import click as ui
 
 ROOT_DIR = Path(__file__).absolute().parent.parent
 CONFIG_DIR = ROOT_DIR / 'config'
@@ -20,6 +21,17 @@ def cli():
 def list():
     for cfg in CONFIG_DIR.glob('*.yaml'):
         print(cfg.name)
+
+
+APP_NAME = 'datacube-fc-launcher'
+@cli.command()
+@click.option('--project', '-P', default='u46')
+@click.option('--queue', '-q', default='normal',
+              type=click.Choice(['normal', 'express']))
+@ui.pass_index(app_name=APP_NAME)
+@click.argument('app_config')
+@click.argument('year', required=False, default=None)
+def launcher(index, app_config, year, queue, project):
 
 
 @cli.command(short_help='Submit a job to qsub',
@@ -140,6 +152,10 @@ def make_fc_taskfile(year, app_config, config_arg, confirm=True):
                       year_arg=year_arg)
     if not confirm or click.confirm('\n' + cmd + '\nRUN?', default=True):
         subprocess.check_call(cmd, shell=True)
+
+        # check the output for "Saved config and %d tasks to %s"
+        # weep into my coffee
+        # Return the number of generated tasks
 
     return taskfile
 

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
     ],
     entry_points={
         'console_scripts': [
-            'datacube-fc = fc.fc_app:fc_app',
+            'datacube-fc = fc.fc_app:cli',
         ]
     },
     ext_modules=[


### PR DESCRIPTION
Split fc into three subcommands


1. submit - Kick of qsub job that runs `generate` command 
2. generate - Generates task file, kicks of run via qsub
3. run - Reads tasks from task file, performs actual computation

I did test run on nci against test db `kk_fc`, seems to work.


