### PR TITLE
Use dea apis to create subjobs, manage state, work directories and logging

### DIFF
--- a/fc/fc_app.py
+++ b/fc/fc_app.py
@@ -268,27 +268,28 @@ def submit(index: Index,
         output_product=app_config['output_type'],
         time=task_datetime
     )
-    work_path.mkdir(parents=True, exist_ok=False)
 
-    task_description_path = work_path.joinpath('task-description.json')
+    task_description = TaskDescription(
+        type_="fc.run",
+        task_dt=task_datetime,
+        events_path=work_path.joinpath('events'),
+        logs_path=work_path.joinpath('logs'),
+        # TODO: Use @datacube.ui.click.parsed_search_expressions to allow params other than time?
+        query=Query(index=index, time=time_range).search_terms,
 
-    serialise.dump_structure(
-        task_description_path,
-        TaskDescription(
-            type_="fc.run",
-            task_dt=task_datetime,
-            events_path=work_path.joinpath('events'),
-            logs_path=work_path.joinpath('logs'),
-            # TODO: Use @datacube.ui.click.parsed_search_expressions to allow params other than time?
-            query=Query(index=index, time=time_range).search_terms,
-
-            # Task-app framework
-            parameters=TaskAppParameters(
-                config_path=app_config_path,
-                task_serialisation_path=work_path.joinpath('generated-tasks.pickle'),
-            )
+        # Task-app framework
+        parameters=TaskAppParameters(
+            config_path=app_config_path,
+            task_serialisation_path=work_path.joinpath('generated-tasks.pickle'),
         )
     )
+
+    work_path.mkdir(parents=True, exist_ok=False)
+    task_description.logs_path.mkdir(parents=True, exist_ok=False)
+    task_description.events_path.mkdir(parents=True, exist_ok=False)
+
+    task_description_path = work_path.joinpath('task-description.json')
+    serialise.dump_structure(task_description_path, task_description)
 
     ret_code, qsub_stdout = qsub('generate',
                                  '-v', '-v',

--- a/fc/fc_app.py
+++ b/fc/fc_app.py
@@ -397,17 +397,13 @@ def run(index,
         task_description_file: str,
         qsub: QSubLauncher,
         runner: TaskRunner,
-        input_tasks_file=None,
         *args, **kwargs):
     _LOG.info('Starting Fractional Cover processing...')
     _LOG.info('Tag: %r', tag)
 
     task_description = _read_task_description(Path(task_description_file))
 
-    if not input_tasks_file:
-        raise click.BadArgumentUsage("No input tasks file given")
-
-    config, tasks = task_app.load_tasks(input_tasks_file)
+    config, tasks = task_app.load_tasks(task_description.parameters.task_serialisation_path)
 
     if dry_run:
         task_app.check_existing_files((task['filename'] for task in tasks))

--- a/fc/fc_app.py
+++ b/fc/fc_app.py
@@ -247,16 +247,6 @@ def submit(index: Index,
            tag: str):
     _LOG.info('Tag: %s', tag)
 
-    qsub = QSubLauncher(norm_qsub_params(
-        {'project': project,
-         'queue': queue,
-         'name': 'fc-generate-{}'.format(tag),
-         'mem': '4G',
-         'noask': True,
-         'wd': True,
-         'ncpus': 1,
-         'walltime': '1h'}))
-
     task_datetime = datetime.utcnow().replace(tzinfo=tz.tzutc())
 
     app_config_path = Path(app_config).resolve()
@@ -294,6 +284,20 @@ def submit(index: Index,
     task_description_path = work_path.joinpath('task-description.json')
     serialise.dump_structure(task_description_path, task_description)
 
+    qsub = QSubLauncher(norm_qsub_params({
+        'project': project,
+        'queue': queue,
+        'name': 'fc-generate-{}'.format(tag),
+        'mem': '4G',
+        'noask': True,
+        'wd': True,
+        'ncpus': 1,
+        'walltime': '1h',
+
+        'umask': 33,
+        'stdout': task_description.logs_path.joinpath('generate-head.out.log'),
+        'stderr': task_description.logs_path.joinpath('generate-head.err.log')
+    }))
     ret_code, qsub_stdout = qsub('generate',
                                  '-v', '-v',
                                  '--project', project,
@@ -364,7 +368,10 @@ def generate(index,
         'noask': True,
         'nodes': nodes,
         'walltime': walltime,
-        # TODO: Add stdout/stderr from log_path
+
+        'umask': 33,
+        'stdout': task_description.logs_path.joinpath('run-head.out.log'),
+        'stderr': task_description.logs_path.joinpath('run-head.err.log')
     }))
 
     ret_code, qsub_stdout = qsub('run',

--- a/fc/fc_app.py
+++ b/fc/fc_app.py
@@ -262,7 +262,9 @@ def submit(app_config,
 @click.option('--project', '-P', default='u46')
 @click.option('--queue', '-q', default='normal',
               type=click.Choice(['normal', 'express']))
-@click.option('--year', 'time_range', callback=task_app.validate_year, help='Limit the process to a particular year')
+@click.option('--year', 'time_range',
+              callback=task_app.validate_year,
+              help='Limit the process to a particular year')
 @click.option('--no-qsub', 'no_qsub', is_flag=True, default=False, help="Skip submitting qsub for next step")
 @tag_option
 @task_app.app_config_option
@@ -279,7 +281,15 @@ def generate(index,
              time_range,
              no_qsub,
              tag):
+    if not output_tasks_file:
+        raise click.MissingParameter("Missing mandatory option '--save-tasks <file>'")
     output_tasks_file = Path(output_tasks_file).absolute()
+
+    if not app_config:
+        raise click.MissingParameter("Missing mandatory option '--app-config <file>'")
+
+    if not time_range:
+        raise click.MissingParameter("Missing mandatory option '--year'")
 
     config, tasks = task_app.load_config(index, app_config, make_fc_config, make_fc_tasks, time_range=time_range)
 

--- a/fc/fc_app.py
+++ b/fc/fc_app.py
@@ -190,6 +190,16 @@ tag_option = click.option('--tag', type=str,
                           default='notset',
                           help='Unique id for the job')
 
+DEFAULT_WORK_FOLDER = '/g/data/v10/work/generate/{output_product}/{work_time:%Y-%m}/{work_time:dT%H%M}'
+
+
+def _get_output_log_folder(config: dict) -> Path:
+    work_folder = DEFAULT_WORK_FOLDER.format(
+        work_time=config['task_timestamp'],
+        output_product=config['output_type'],
+    )
+    return Path(work_folder)
+
 
 @click.group(help='Datacube Fractional Cover')
 def cli():
@@ -315,6 +325,8 @@ def generate(index,
         _LOG.info('Quitting early as requested')
         return 0
 
+    log_path = _get_output_log_folder(config)
+
     qsub = QSubLauncher(norm_qsub_params(
         {'project': project,
          'queue': queue,
@@ -323,7 +335,9 @@ def generate(index,
          'wd': True,
          'noask': True,
          'nodes': nodes,
-         'walltime': walltime}))
+         'walltime': walltime,
+         # TODO: Add stdout/stderr from log_path
+         }))
 
     ret_code, qsub_stdout = qsub('run',
                                  '-v', '-v',

--- a/fc/fc_app.py
+++ b/fc/fc_app.py
@@ -364,7 +364,11 @@ def run(index,
     task_func = partial(do_fc_task, config)
     process_func = partial(process_result, index)
 
-    runner(tasks, task_func, process_func)
+    try:
+        runner(tasks, task_func, process_func)
+        _LOG.info("Runner finished normally, triggering shutdown.")
+    finally:
+        runner.stop()
 
 
 if __name__ == "__main__":

--- a/fc/fc_app.py
+++ b/fc/fc_app.py
@@ -24,6 +24,7 @@ from datacube.ui import task_app
 from datacube.utils import unsqueeze_dataset
 from digitalearthau.qsub import QSubLauncher, with_qsub_runner, norm_qsub_params, TaskRunner
 from fc.fractional_cover import fractional_cover
+from datacube.index._api import Index
 
 _LOG = logging.getLogger('agdc-fc')
 
@@ -171,10 +172,10 @@ def do_fc_task(config, task):
     return datasets
 
 
-def process_result(index, result):
+def process_result(index: Index, result):
     for dataset in result.values:
         index.datasets.add(dataset, sources_policy='skip')
-        _LOG.info('Dataset added')
+        _LOG.info('Dataset %s added at %s', dataset.id, dataset.uris)
 
 
 APP_NAME = 'datacube-fc'

--- a/fc/fc_app.py
+++ b/fc/fc_app.py
@@ -3,23 +3,22 @@ from __future__ import absolute_import, print_function, division
 import errno
 import logging
 import os
+import sys
 from copy import deepcopy
-from datetime import datetime
 from functools import partial
-from time import time as time_now
 from math import ceil
 from pathlib import Path
+from time import time as time_now
 
 import click
-import sys
-
+from datetime import datetime
+from dateutil import tz
 from pandas import to_datetime
 from typing import Tuple
 
-from dateutil import tz
-
 from datacube.api.grid_workflow import GridWorkflow
 from datacube.api.query import Query
+from datacube.index._api import Index
 from datacube.model import DatasetType, GeoPolygon
 from datacube.model.utils import make_dataset, xr_apply, datasets_to_doc
 from datacube.storage.storage import write_dataset_to_netcdf
@@ -30,7 +29,6 @@ from digitalearthau import paths, serialise
 from digitalearthau.qsub import QSubLauncher, with_qsub_runner, norm_qsub_params, TaskRunner
 from digitalearthau.runners.model import TaskAppState, TaskDescription, DefaultJobParameters
 from fc.fractional_cover import fractional_cover
-from datacube.index._api import Index
 
 _LOG = logging.getLogger('agdc-fc')
 
@@ -357,17 +355,17 @@ def generate(index,
         _LOG.info('Quitting early as requested')
         return 0
 
-    qsub = QSubLauncher(norm_qsub_params(
-        {'project': project,
-         'queue': queue,
-         'name': 'fc-run-{}'.format(tag),
-         'mem': 'small',
-         'wd': True,
-         'noask': True,
-         'nodes': nodes,
-         'walltime': walltime,
-         # TODO: Add stdout/stderr from log_path
-         }))
+    qsub = QSubLauncher(norm_qsub_params({
+        'project': project,
+        'queue': queue,
+        'name': 'fc-run-{}'.format(tag),
+        'mem': 'small',
+        'wd': True,
+        'noask': True,
+        'nodes': nodes,
+        'walltime': walltime,
+        # TODO: Add stdout/stderr from log_path
+    }))
 
     ret_code, qsub_stdout = qsub('run',
                                  '-v', '-v',

--- a/fc/fc_app.py
+++ b/fc/fc_app.py
@@ -4,6 +4,7 @@ import errno
 import logging
 import os
 from copy import deepcopy
+from datetime import datetime
 from functools import partial
 from time import time as time_now
 from math import ceil
@@ -12,6 +13,7 @@ from pathlib import Path
 import click
 import sys
 from pandas import to_datetime
+from typing import Tuple
 
 from datacube.api.grid_workflow import GridWorkflow
 from datacube.model import DatasetType, GeoPolygon
@@ -85,14 +87,18 @@ def get_filename(config, tile_index, sources):
                                      version=config['task_timestamp'])
 
 
-def make_fc_tasks(index, config, time_range=None, **kwargs):
+def make_fc_tasks(index,
+                  config,
+                  time_range: Tuple[datetime, datetime] = None,
+                  **kwargs):
     input_type = config['nbar_dataset_type']
     output_type = config['fc_dataset_type']
 
     workflow = GridWorkflow(index, output_type.grid_spec)
-
     tiles_in = workflow.list_tiles(product=input_type.name, time=time_range)
+    _LOG.info(f"{len(tiles_in)} {input_type.name} tiles in {time_range}")
     tiles_out = workflow.list_tiles(product=output_type.name, time=time_range)
+    _LOG.info(f"{len(tiles_out)} {output_type.name} tiles in {time_range}")
 
     def make_task(tile, **task_kwargs):
         task = dict(nbar=workflow.update_tile_lineage(tile))
@@ -231,7 +237,6 @@ def submit(app_config,
            output_tasks_file,
            year,
            tag):
-
     _LOG.info('Tag: %s', tag)
 
     qsub = QSubLauncher(norm_qsub_params(
@@ -343,7 +348,6 @@ def run(index,
         qsub, runner,
         input_tasks_file=None,
         *args, **kwargs):
-
     _LOG.info('Starting Fractional Cover processing...')
     _LOG.info('Tag: %s', tag)
 

--- a/fc/fc_app.py
+++ b/fc/fc_app.py
@@ -258,7 +258,7 @@ def submit(index: Index,
         output_product=output_type,
         time=task_datetime
     )
-
+    # TODO: most of this task_description->qsub setup code can become a common function
     task_description = TaskDescription(
         type_="fc",
         task_dt=task_datetime,
@@ -277,7 +277,6 @@ def submit(index: Index,
         )
     )
 
-    work_path.mkdir(parents=True, exist_ok=False)
     task_description.logs_path.mkdir(parents=True, exist_ok=False)
     task_description.events_path.mkdir(parents=True, exist_ok=False)
 

--- a/fc/fc_app.py
+++ b/fc/fc_app.py
@@ -256,7 +256,7 @@ def submit(index: Index,
     output_type = app_config['output_type']
     source_type = app_config['source_type']
 
-    task_description, task_description_path = init_task_app(
+    task_desc, task_path = init_task_app(
         job_type="fc",
         source_types=[source_type],
         output_types=[output_type],
@@ -265,7 +265,7 @@ def submit(index: Index,
         pbs_project=project,
         pbs_queue=queue
     )
-    _LOG.info("Created task description: %s", task_description_path)
+    _LOG.info("Created task description: %s", task_path)
 
     if no_qsub:
         _LOG.info('Skipping submission due to --no-qsub')
@@ -273,10 +273,10 @@ def submit(index: Index,
 
     job_id = submit_subjob(
         name='generate',
-        task_description=task_description,
+        task_desc=task_desc,
         command=[
             'generate', '-v', '-v',
-            '--task-description', str(task_description_path),
+            '--task-desc', str(task_path),
             '--tag', tag
         ],
         qsub_params=dict(
@@ -292,7 +292,7 @@ def submit(index: Index,
 @cli.command(help='Generate Tasks into file and Queue PBS job to process them')
 @click.option('--no-qsub', is_flag=True, default=False, help="Skip submitting qsub for next step")
 @click.option(
-    '--task-description', 'task_description_file', help='',
+    '--task-desc', 'task_desc_file', help='Task environment description file',
     required=True,
     type=click.Path(exists=True, readable=True, writable=False, dir_okay=False)
 )
@@ -301,17 +301,17 @@ def submit(index: Index,
 @ui.log_queries_option
 @ui.pass_index(app_name=APP_NAME)
 def generate(index: Index,
-             task_description_file: str,
+             task_desc_file: str,
              no_qsub: bool,
              tag: str):
     _LOG.info('Tag: %s', tag)
 
-    config, task_description = _read_config_and_description(index, Path(task_description_file))
+    config, task_desc = _make_config_and_description(index, Path(task_desc_file))
 
     num_tasks_saved = task_app.save_tasks(
         config,
-        make_fc_tasks(index, config, query=task_description.parameters.query),
-        task_description.runtime_state.task_serialisation_path
+        make_fc_tasks(index, config, query=task_desc.parameters.query),
+        task_desc.runtime_state.task_serialisation_path
     )
     _LOG.info('Found %d tasks', num_tasks_saved)
 
@@ -329,12 +329,12 @@ def generate(index: Index,
 
     job_id = submit_subjob(
         name='run',
-        task_description=task_description,
+        task_desc=task_desc,
 
         command=[
             'run',
             '-vv',
-            '--task-description', str(task_description_file),
+            '--task-desc', str(task_desc_file),
             '--celery', 'pbs-launch',
             '--tag', tag,
         ],
@@ -348,11 +348,11 @@ def generate(index: Index,
     )
 
 
-def _read_config_and_description(index: Index, task_description_path: Path) -> Tuple[dict, TaskDescription]:
-    task_description = serialise.load_structure(task_description_path, TaskDescription)
+def _make_config_and_description(index: Index, task_desc_path: Path) -> Tuple[dict, TaskDescription]:
+    task_desc = serialise.load_structure(task_desc_path, TaskDescription)
 
-    task_time: datetime = task_description.task_dt
-    app_config = task_description.runtime_state.config_path
+    task_time: datetime = task_desc.task_dt
+    app_config = task_desc.runtime_state.config_path
 
     config = paths.read_document(app_config)
 
@@ -362,13 +362,13 @@ def _read_config_and_description(index: Index, task_description_path: Path) -> T
     config['app_config_file'] = Path(app_config).name
     config = make_fc_config(index, config)
 
-    return config, task_description
+    return config, task_desc
 
 
 @cli.command(help='Actually process generated task file')
 @click.option('--dry-run', is_flag=True, default=False, help='Check if output files already exist')
 @click.option(
-    '--task-description', 'task_description_file', help='',
+    '--task-desc', 'task_desc_file', help='Task environment description file',
     required=True,
     type=click.Path(exists=True, readable=True, writable=False, dir_okay=False)
 )
@@ -381,16 +381,16 @@ def _read_config_and_description(index: Index, task_description_path: Path) -> T
 def run(index,
         dry_run: bool,
         tag: str,
-        task_description_file: str,
+        task_desc_file: str,
         qsub: QSubLauncher,
         runner: TaskRunner,
         *args, **kwargs):
     _LOG.info('Starting Fractional Cover processing...')
     _LOG.info('Tag: %r', tag)
 
-    task_description = serialise.load_structure(Path(task_description_file), TaskDescription)
+    task_desc = serialise.load_structure(Path(task_desc_file), TaskDescription)
 
-    config, tasks = task_app.load_tasks(task_description.runtime_state.task_serialisation_path)
+    config, tasks = task_app.load_tasks(task_desc.runtime_state.task_serialisation_path)
 
     if dry_run:
         task_app.check_existing_files((task['filename'] for task in tasks))
@@ -400,7 +400,7 @@ def run(index,
     process_func = partial(process_result, index)
 
     try:
-        runner(task_description, tasks, task_func, process_func)
+        runner(task_desc, tasks, task_func, process_func)
         _LOG.info("Runner finished normally, triggering shutdown.")
     finally:
         runner.stop()

--- a/fc/fc_app.py
+++ b/fc/fc_app.py
@@ -261,17 +261,18 @@ def submit(index: Index,
 
     task_datetime = datetime.utcnow().replace(tzinfo=tz.tzutc())
 
-    app_config_path = Path(app_config).absolute()
+    app_config_path = Path(app_config).resolve()
     app_config = paths.read_document(app_config_path)
 
     work_path = paths.get_product_work_directory(
         output_product=app_config['output_type'],
-        submission_time=task_datetime
+        time=task_datetime
     )
+    work_path.mkdir(parents=True, exist_ok=False)
 
-    task_description_path = work_path.joinpath('task-description.yaml')
+    task_description_path = work_path.joinpath('task-description.json')
 
-    serialise.dump_document(
+    serialise.dump_structure(
         task_description_path,
         TaskDescription(
             type_="fc.run",
@@ -286,8 +287,7 @@ def submit(index: Index,
                 config_path=app_config_path,
                 task_serialisation_path=work_path.joinpath('generated-tasks.pickle'),
             )
-        ),
-        allow_unsafe=True
+        )
     )
 
     ret_code, qsub_stdout = qsub('generate',
@@ -374,8 +374,7 @@ def generate(index,
 
 
 def _read_task_description(task_description_file: Path) -> TaskDescription:
-    d = paths.read_document(task_description_file)
-    raise NotImplementedError("TODO")
+    return serialise.load_structure(task_description_file, TaskDescription)
 
 
 @cli.command(help='Actually process generated task file')

--- a/fc/fc_app.py
+++ b/fc/fc_app.py
@@ -253,13 +253,11 @@ def submit(index: Index,
     app_config_path = Path(app_config).resolve()
     app_config = paths.read_document(app_config_path)
 
-    output_type = app_config['output_type']
-    source_type = app_config['source_type']
-
     task_desc, task_path = init_task_app(
         job_type="fc",
-        source_types=[source_type],
-        output_types=[output_type],
+        source_types=[app_config['source_type']],
+        output_types=[app_config['output_type']],
+        # TODO: Use @datacube.ui.click.parsed_search_expressions to allow params other than time from the cli?
         datacube_query_args=Query(index=index, time=time_range).search_terms,
         app_config_path=app_config_path,
         pbs_project=project,
@@ -271,7 +269,7 @@ def submit(index: Index,
         _LOG.info('Skipping submission due to --no-qsub')
         return 0
 
-    job_id = submit_subjob(
+    submit_subjob(
         name='generate',
         task_desc=task_desc,
         command=[
@@ -320,14 +318,13 @@ def generate(index: Index,
         sys.exit(0)
 
     nodes, walltime = estimate_job_size(num_tasks_saved)
-
     _LOG.info('Will request %d nodes and %s time', nodes, walltime)
 
     if no_qsub:
         _LOG.info('Skipping submission due to --no-qsub')
         return 0
 
-    job_id = submit_subjob(
+    submit_subjob(
         name='run',
         task_desc=task_desc,
 
@@ -389,7 +386,6 @@ def run(index,
     _LOG.info('Tag: %r', tag)
 
     task_desc = serialise.load_structure(Path(task_desc_file), TaskDescription)
-
     config, tasks = task_app.load_tasks(task_desc.runtime_state.task_serialisation_path)
 
     if dry_run:

--- a/fc/fc_app.py
+++ b/fc/fc_app.py
@@ -10,6 +10,7 @@ from math import ceil
 from pathlib import Path
 
 import click
+import sys
 from pandas import to_datetime
 
 from datacube.api.grid_workflow import GridWorkflow
@@ -296,6 +297,9 @@ def generate(index,
     num_tasks_saved = task_app.save_tasks(config, tasks, output_tasks_file)
     _LOG.info('Tag: %s', tag)
     _LOG.info('Found %d tasks', num_tasks_saved)
+    if not num_tasks_saved:
+        _LOG.info("No tasks. Finishing.")
+        sys.exit(0)
 
     nodes, walltime = estimate_job_size(num_tasks_saved)
 

--- a/fc/fc_app.py
+++ b/fc/fc_app.py
@@ -22,7 +22,7 @@ from datacube.storage.storage import write_dataset_to_netcdf
 from datacube.ui import click as ui
 from datacube.ui import task_app
 from datacube.utils import unsqueeze_dataset
-from digitalearthau.qsub import QSubLauncher, with_qsub_runner, norm_qsub_params
+from digitalearthau.qsub import QSubLauncher, with_qsub_runner, norm_qsub_params, TaskRunner
 from fc.fractional_cover import fractional_cover
 
 _LOG = logging.getLogger('agdc-fc')
@@ -345,14 +345,17 @@ def generate(index,
 def run(index,
         dry_run,
         tag,
-        qsub, runner,
+        qsub: QSubLauncher,
+        runner: TaskRunner,
         input_tasks_file=None,
         *args, **kwargs):
     _LOG.info('Starting Fractional Cover processing...')
-    _LOG.info('Tag: %s', tag)
+    _LOG.info('Tag: %r', tag)
 
-    if input_tasks_file:
-        config, tasks = task_app.load_tasks(input_tasks_file)
+    if not input_tasks_file:
+        raise click.BadArgumentUsage("No input tasks file given")
+
+    config, tasks = task_app.load_tasks(input_tasks_file)
 
     if dry_run:
         task_app.check_existing_files((task['filename'] for task in tasks))


### PR DESCRIPTION
Note that Travis will fail until the DEA patch is merged: GeoscienceAustralia/digitalearthau#32

I'm raising this now as an example of using the apis.  See that pull request for the folder structure currently used.

Notes:
- The app is no longer managing locations of pickled task files, pbs parameters between jobs, etc. Most "decisions" about pbs jobs I'm trying to move to the common dea lib.
- umask/etc are set by default by the dea apis (default is currently set to 33 at the moment, which we used on previous jobs)