### PR TITLE
 Rename `source_types` to `source_products`, add load config command

### DIFF
--- a/fc/fc_app.py
+++ b/fc/fc_app.py
@@ -271,8 +271,8 @@ def submit(index: Index,
 
     task_desc, task_path = init_task_app(
         job_type="fc",
-        source_types=[app_config['source_type']],
-        output_types=[app_config['output_type']],
+        source_products=[app_config['source_type']],
+        output_products=[app_config['output_type']],
         # TODO: Use @datacube.ui.click.parsed_search_expressions to allow params other than time from the cli?
         datacube_query_args=Query(index=index, time=time_range).search_terms,
         app_config_path=app_config_path,

--- a/fc/fc_app.py
+++ b/fc/fc_app.py
@@ -33,7 +33,7 @@ from fc.fractional_cover import fractional_cover
 _LOG = logging.getLogger('agdc-fc')
 
 
-def make_fc_config(index, config, dry_run=False, **kwargs):
+def make_fc_config(index: Index, config, dry_run=False, **kwargs):
     source_type = index.products.get_by_name(config['source_type'])
     if not source_type:
         _LOG.error("Source DatasetType %s does not exist", config['source_type'])
@@ -204,6 +204,22 @@ def cli():
 def list_configs():
     for cfg in CONFIG_DIR.glob('*.yaml'):
         print(cfg.name)
+
+
+@cli.command(help='Add FC product definitions to the datacube')
+@click.argument(
+    'app-config-files',
+    nargs=-1,
+    type=click.Path(exists=True, readable=True, writable=False, dir_okay=False)
+)
+@ui.config_option
+@ui.verbose_option
+@ui.pass_index(app_name=APP_NAME)
+def load_config(index, app_config_files):
+    for app_config_file in app_config_files:
+        click.secho(f"Loading {app_config_file}", bold=True)
+        app_config = paths.read_document(Path(app_config_file))
+        make_fc_config(index, app_config)
 
 
 def estimate_job_size(num_tasks):


### PR DESCRIPTION
Matches the api change in GeoscienceAustralia/digitalearthau#35. 

I'm sneaking a second change in this pull request, but I can split them if needed.

The second change adds command `load_config` to generate and add FC product definitions to a datacube (from a given FC config file) without needing to process first. It's useful when indexing existing FC files in my own datacube.