### PR TITLE
Fix up Travis-CI AWS credentials

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,9 +47,6 @@ before_deploy:
 
 deploy:
  - provider: s3
-   access_key_id: "AKIAJMZN4F5L5KXPQKVQ"
-   secret_access_key:
-       secure: kI1RNrgnAJil2/d1ut5JOypWrZhgSt6MHNpRMK5zpEoB+RaKAshq+b7Npw5TFQ9crmJ9Z5qwMGoaA9/b8Y7x4bM38oaaDkh3QEQw02YV9DjLOtfegBgfxjXMcwP9BdKjGiqZaq0akK4TyCdZq4Vmu+vDNDP4WJIqoyH4az7TpqxflqWgGUote1Rxlng12bvXGgk0t5GvGFUkQOLgD6CUVqj6cV/NAIOCtvxONDYorVCcL/ZhPyzH1JSKLLLaObupIKr4yOAJ7NO/Zysf3dU0GKPEAmiCqWp5gPGVQGRGIQORgYHIf2eZDSd4sgmMZrPM30KpIN8fTF5VYq1w/4S2ZNMSElVbwm4qOhnF8LNip/GKFtteV5hsq5cLB4usHZaxOuklISc5Ck6vY2l2waLQyRcNIeqB8wXwyp1xNGSkw+jfT3gPQNXtnNO2aoT7CJU5qD/9EZGs6UuVc7nP1GJkYYGn9JLSPhybCTWA3Aj4nhX/3EKoNTPU2Peu/2LlXJ+Sn74sQqOCdKQ0fqRRmR+oVxRmKtCGLaqIjs8NZih6FRM0S+By7EmAEF7zADH1/I6+nwjRA8djOBc434lVdURJSTFwAsOT20ZokQNxdDJkcusJjPlYLnawWxUl90XADzwJj96rRc5Nx+Di4IU5dhGLuDUSxsOHrrY5z18VCwNWMOM=
    bucket: "datacube-core-deployment"
    region: "ap-southeast-2"
    local_dir: dist

--- a/tests/test_fractional_cover.py
+++ b/tests/test_fractional_cover.py
@@ -7,7 +7,7 @@ from __future__ import absolute_import, print_function
 import pytest
 import xarray as xr
 import datacube.utils.geometry
-
+from datacube.model import Measurement
 from fc.fractional_cover import fractional_cover
 
 
@@ -18,10 +18,10 @@ def test_fractional_cover(sr_filepath, fc_filepath):
     sr_dataset = open_dataset(sr_filepath)
 
     measurements = [
-        {'name': 'PV', 'dtype': 'int8', 'nodata': -1, 'units': 'percent'},
-        {'name': 'NPV', 'dtype': 'int8', 'nodata': -1, 'units': 'percent'},
-        {'name': 'BS', 'dtype': 'int8', 'nodata': -1, 'units': 'percent'},
-        {'name': 'UE', 'dtype': 'int8', 'nodata': -1, 'units': '1'}
+        Measurement(name='PV', dtype='int8', nodata=-1, units='percent'),
+        Measurement(name='NPV', dtype='int8', nodata=-1, units='percent'),
+        Measurement(name='BS', dtype='int8', nodata=-1, units='percent'),
+        Measurement(name='UE', dtype='int8', nodata=-1, units='1'),
     ]
 
     fc_dataset = fractional_cover(sr_dataset, measurements)


### PR DESCRIPTION
Store them in Travis environment variables instead of the .travis.yml configuration file.

They'll be easier to maintain and rotate there.