### PR TITLE
Add email monitoring

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -78,16 +78,19 @@ Usage: ``datacube-fc submit [OPTIONS]``
 
 Options:
 
-* ``-q, --queue [normal|express]``       The queue to use, either ``normal`` or ``express``
-* ``-P, --project TEXT``                 The project to use
-* ``--year TEXT``                        Limit the process to a particular year
-* ``--no-qsub``                          Skip submitting job
-* ``--tag TEXT``                         Unique id for the job
-* ``--app-config PATH``                  Fractional Cover app configuration file
-* ``--dry-run``                          Do not record anything into the database
-* ``-C, --config, --config_file TEXT``   Datacube config file (by default uses the currently loaded AGDC module)
-* ``-v, --verbose``                      Use multiple times for more verbosity
-* ``--help``                             Show help message.
+* ``-q, --queue [normal|express]``                 The queue to use, either ``normal`` or ``express``
+* ``-P, --project TEXT``                           The project to use
+* ``--year TEXT``                                  Limit the process to a particular year
+* ``--no-qsub``                                    Skip submitting job
+* ``--tag TEXT``                                   Unique id for the job
+* ``--app-config PATH``                            Fractional Cover app configuration file
+* ``--dry-run``                                    Do not record anything into the database
+* ``-m, --email-options [a|b|e|n|ae|ab|be|abe]``   Send Email when execution is,
+                                                     [a = aborted | b = begins | e = ends | n = do not send email]
+* ``-M, --email-id TEXT``                          Email Recipient List
+* ``-C, --config, --config_file TEXT``             Datacube config file
+* ``-v, --verbose``                                Use multiple times for more verbosity
+* ``--help``                                       Show help message.
 
 Tracking progress
 -----------------

--- a/fc/fc_app.py
+++ b/fc/fc_app.py
@@ -414,6 +414,8 @@ def submit(index: Index,
             '--task-desc', str(task_path),
             '--tag', tag,
             '--log-queries',
+            '--email-id', email_id,
+            '--email-options', email_options,
             dry_run_option,
         ],
         qsub_params=dict(

--- a/fc/fc_app.py
+++ b/fc/fc_app.py
@@ -289,15 +289,15 @@ def list_configs():
 @ui.config_option
 @ui.verbose_option
 @ui.pass_index(app_name=APP_NAME)
-def ensure_products(index, app_config_file, dry_run):
+def ensure_products(index, app_config, dry_run):
     """
     Ensure the products exist for the given FC config, creating them if necessary.
     If dry run is disabled, the validated output product definition will be added to the database.
     """
     # TODO: Add more validation of config?
-    click.secho(f"Loading {app_config_file}", bold=True)
-    app_config = paths.read_document(app_config_file)
-    _, out_product = _ensure_products(app_config, index, dry_run)
+    click.secho(f"Loading {app_config}", bold=True)
+    app_config_file = paths.read_document(app_config)
+    _, out_product = _ensure_products(app_config_file, index, dry_run)
     click.secho(f"Output product definition for {out_product.name} product exits in the database for the given "
                 f"FC input config file")
 

--- a/fc/fc_app.py
+++ b/fc/fc_app.py
@@ -34,7 +34,7 @@ from datacube.ui import click as ui
 from datacube.ui import task_app
 from datacube.utils import unsqueeze_dataset
 from digitalearthau import paths, serialise
-from digitalearthau.qsub import QSubLauncher, with_qsub_runner, TaskRunner, norm_qsub_params
+from digitalearthau.qsub import QSubLauncher, with_qsub_runner, TaskRunner
 from digitalearthau.runners.model import TaskDescription
 from digitalearthau.runners.util import submit_subjob, init_task_app
 from fc import __version__
@@ -419,7 +419,7 @@ def submit(index: Index,
         ],
         qsub_params=dict(
             name='fc-generate-{}'.format(tag),
-            mem='small',
+            mem='medium',
             wd=True,
             nodes=1,
             walltime='1h'

--- a/fc/fc_app.py
+++ b/fc/fc_app.py
@@ -243,7 +243,7 @@ tag_option = click.option('--tag', type=str,
                           help='Unique id for the job')
 
 # pylint: disable=invalid-name
-pbs_email_options = click.option('--email-options', '-m', default='ae',
+pbs_email_options = click.option('--email-options', '-m', default='abe',
                                  type=click.Choice(['a', 'b', 'e', 'n', 'ae', 'ab', 'be', 'abe']),
                                  help='Send Email when execution is, \n'
                                  '[a = aborted | b = begins | e = ends | n = do not send email]')
@@ -280,8 +280,7 @@ def list_configs():
 
 
 @cli.command(name='ensure-products',
-             help="Ensure the products exist for the given FC config, creating them if necessary."
-)
+             help="Ensure the products exist for the given FC config, creating them if necessary.")
 @click.option('--app-config', help='App configuration file',
               type=click.Path(exists=True, readable=True, writable=False, dir_okay=False),
               required=True)


### PR DESCRIPTION
**Reason for this pull request**
Qsub job status monitoring via email is missing in the existing `fc_app` code. Adding `pbs` job monitoring via email would help in monitoring the PBS jobs in an efficient way.

**Proposed solutions**
Update the `fc_app.py` to notify via email whenever a pbs job is `successfully executed` or `failed to execute` or `aborted`.

- [x] Tests passed (no update to tests required, as the test scenarios were already written as part of `dea-env` testing)
