### PR TITLE
Add metadata format name

### DIFF
--- a/config/ls5_fc_albers.yaml
+++ b/config/ls5_fc_albers.yaml
@@ -78,14 +78,6 @@ global_attributes:
     - Muir, J., Schmidt, M., Tindall, D., Trevithick, R., Scarth, P., Stewart, J., 2011. Guidelines for Field measurement of fractional ground cover: a technical handbook supporting the Australian collaborative land use and management program. Tech. rep., Queensland Department of Environment and Resource Management for the Australian Bureau of Agricultural and Resource Economics and Sciences, Canberra.
     - Scarth, P., Roder, A. and Schmidt, M., 2010. Tracking grazing pressure and climate interaction -  the role of Landsat fractional cover in the time series analysis, Proceedings of the 15th Australasian Remote Sensing & Photogrammetry Conference, viewed 4 January 2011, scribd.com/doc/37455672/15arspc-Submission-140.
     - Schmidt, M., Denham, R. and Scarth, P., 2010. 'Fractional ground cover monitoring of pastures and agricultural areas in Queensland', Proceedings of the 15th Australasian Remote Sensing & Photogrammetry Conference, viewed 4 January 2011, www.scribd.com/doc/37455826/15arspc-Submission-119.
-metadata:
-    format:
-        name: NetCDF
-    instrument:
-        name: TM
-    platform:
-        code: LANDSAT_5
-    product_type: fractional_cover
 storage:
   driver: NetCDF
 

--- a/config/ls5_fc_albers.yaml
+++ b/config/ls5_fc_albers.yaml
@@ -78,12 +78,19 @@ global_attributes:
     - Muir, J., Schmidt, M., Tindall, D., Trevithick, R., Scarth, P., Stewart, J., 2011. Guidelines for Field measurement of fractional ground cover: a technical handbook supporting the Australian collaborative land use and management program. Tech. rep., Queensland Department of Environment and Resource Management for the Australian Bureau of Agricultural and Resource Economics and Sciences, Canberra.
     - Scarth, P., Roder, A. and Schmidt, M., 2010. Tracking grazing pressure and climate interaction -  the role of Landsat fractional cover in the time series analysis, Proceedings of the 15th Australasian Remote Sensing & Photogrammetry Conference, viewed 4 January 2011, scribd.com/doc/37455672/15arspc-Submission-140.
     - Schmidt, M., Denham, R. and Scarth, P., 2010. 'Fractional ground cover monitoring of pastures and agricultural areas in Queensland', Proceedings of the 15th Australasian Remote Sensing & Photogrammetry Conference, viewed 4 January 2011, www.scribd.com/doc/37455826/15arspc-Submission-119.
+metadata:
+    format:
+        name: NetCDF
+    instrument:
+        name: TM
+    platform:
+        code: LANDSAT_5
+    product_type: fractional_cover
 storage:
   driver: NetCDF CF
 
   crs: EPSG:3577
   tile_size:
-          x: 100000.0
           x: 100000.0
           y: 100000.0
   resolution:

--- a/config/ls5_fc_albers.yaml
+++ b/config/ls5_fc_albers.yaml
@@ -87,7 +87,7 @@ metadata:
         code: LANDSAT_5
     product_type: fractional_cover
 storage:
-  driver: NetCDF CF
+  driver: NetCDF
 
   crs: EPSG:3577
   tile_size:

--- a/config/ls7_fc_albers.yaml
+++ b/config/ls7_fc_albers.yaml
@@ -78,6 +78,14 @@ global_attributes:
     - Muir, J., Schmidt, M., Tindall, D., Trevithick, R., Scarth, P., Stewart, J., 2011. Guidelines for Field measurement of fractional ground cover: a technical handbook supporting the Australian collaborative land use and management program. Tech. rep., Queensland Department of Environment and Resource Management for the Australian Bureau of Agricultural and Resource Economics and Sciences, Canberra.
     - Scarth, P., Roder, A. and Schmidt, M., 2010. Tracking grazing pressure and climate interaction -  the role of Landsat fractional cover in the time series analysis, Proceedings of the 15th Australasian Remote Sensing & Photogrammetry Conference, viewed 4 January 2011, scribd.com/doc/37455672/15arspc-Submission-140.
     - Schmidt, M., Denham, R. and Scarth, P., 2010. 'Fractional ground cover monitoring of pastures and agricultural areas in Queensland', Proceedings of the 15th Australasian Remote Sensing & Photogrammetry Conference, viewed 4 January 2011, www.scribd.com/doc/37455826/15arspc-Submission-119.
+metadata:
+    format:
+        name: NetCDF
+    instrument:
+        name: ETM
+    platform:
+        code: LANDSAT_7
+    product_type: fractional_cover
 storage:
   driver: NetCDF CF
 

--- a/config/ls7_fc_albers.yaml
+++ b/config/ls7_fc_albers.yaml
@@ -78,14 +78,6 @@ global_attributes:
     - Muir, J., Schmidt, M., Tindall, D., Trevithick, R., Scarth, P., Stewart, J., 2011. Guidelines for Field measurement of fractional ground cover: a technical handbook supporting the Australian collaborative land use and management program. Tech. rep., Queensland Department of Environment and Resource Management for the Australian Bureau of Agricultural and Resource Economics and Sciences, Canberra.
     - Scarth, P., Roder, A. and Schmidt, M., 2010. Tracking grazing pressure and climate interaction -  the role of Landsat fractional cover in the time series analysis, Proceedings of the 15th Australasian Remote Sensing & Photogrammetry Conference, viewed 4 January 2011, scribd.com/doc/37455672/15arspc-Submission-140.
     - Schmidt, M., Denham, R. and Scarth, P., 2010. 'Fractional ground cover monitoring of pastures and agricultural areas in Queensland', Proceedings of the 15th Australasian Remote Sensing & Photogrammetry Conference, viewed 4 January 2011, www.scribd.com/doc/37455826/15arspc-Submission-119.
-metadata:
-    format:
-        name: NetCDF
-    instrument:
-        name: ETM
-    platform:
-        code: LANDSAT_7
-    product_type: fractional_cover
 storage:
   driver: NetCDF
 

--- a/config/ls7_fc_albers.yaml
+++ b/config/ls7_fc_albers.yaml
@@ -87,7 +87,7 @@ metadata:
         code: LANDSAT_7
     product_type: fractional_cover
 storage:
-  driver: NetCDF CF
+  driver: NetCDF
 
   crs: EPSG:3577
   tile_size:

--- a/config/ls8_fc_albers.yaml
+++ b/config/ls8_fc_albers.yaml
@@ -98,14 +98,6 @@ global_attributes:
     - Muir, J., Schmidt, M., Tindall, D., Trevithick, R., Scarth, P., Stewart, J., 2011. Guidelines for Field measurement of fractional ground cover: a technical handbook supporting the Australian collaborative land use and management program. Tech. rep., Queensland Department of Environment and Resource Management for the Australian Bureau of Agricultural and Resource Economics and Sciences, Canberra.
     - Scarth, P., Roder, A. and Schmidt, M., 2010. Tracking grazing pressure and climate interaction -  the role of Landsat fractional cover in the time series analysis, Proceedings of the 15th Australasian Remote Sensing & Photogrammetry Conference, viewed 4 January 2011, scribd.com/doc/37455672/15arspc-Submission-140.
     - Schmidt, M., Denham, R. and Scarth, P., 2010. 'Fractional ground cover monitoring of pastures and agricultural areas in Queensland', Proceedings of the 15th Australasian Remote Sensing & Photogrammetry Conference, viewed 4 January 2011, www.scribd.com/doc/37455826/15arspc-Submission-119.
-metadata:
-    format:
-        name: NetCDF
-    instrument:
-        name: OLI_TIRS
-    platform:
-        code: LANDSAT_8
-    product_type: fractional_cover
 storage:
   driver: NetCDF
 

--- a/config/ls8_fc_albers.yaml
+++ b/config/ls8_fc_albers.yaml
@@ -98,7 +98,6 @@ global_attributes:
     - Muir, J., Schmidt, M., Tindall, D., Trevithick, R., Scarth, P., Stewart, J., 2011. Guidelines for Field measurement of fractional ground cover: a technical handbook supporting the Australian collaborative land use and management program. Tech. rep., Queensland Department of Environment and Resource Management for the Australian Bureau of Agricultural and Resource Economics and Sciences, Canberra.
     - Scarth, P., Roder, A. and Schmidt, M., 2010. Tracking grazing pressure and climate interaction -  the role of Landsat fractional cover in the time series analysis, Proceedings of the 15th Australasian Remote Sensing & Photogrammetry Conference, viewed 4 January 2011, scribd.com/doc/37455672/15arspc-Submission-140.
     - Schmidt, M., Denham, R. and Scarth, P., 2010. 'Fractional ground cover monitoring of pastures and agricultural areas in Queensland', Proceedings of the 15th Australasian Remote Sensing & Photogrammetry Conference, viewed 4 January 2011, www.scribd.com/doc/37455826/15arspc-Submission-119.
-
 metadata:
     format:
         name: NetCDF

--- a/config/ls8_fc_albers.yaml
+++ b/config/ls8_fc_albers.yaml
@@ -107,7 +107,7 @@ metadata:
         code: LANDSAT_8
     product_type: fractional_cover
 storage:
-  driver: NetCDF CF
+  driver: NetCDF
 
   crs: EPSG:3577
   tile_size:

--- a/config/ls8_fc_albers.yaml
+++ b/config/ls8_fc_albers.yaml
@@ -99,6 +99,14 @@ global_attributes:
     - Scarth, P., Roder, A. and Schmidt, M., 2010. Tracking grazing pressure and climate interaction -  the role of Landsat fractional cover in the time series analysis, Proceedings of the 15th Australasian Remote Sensing & Photogrammetry Conference, viewed 4 January 2011, scribd.com/doc/37455672/15arspc-Submission-140.
     - Schmidt, M., Denham, R. and Scarth, P., 2010. 'Fractional ground cover monitoring of pastures and agricultural areas in Queensland', Proceedings of the 15th Australasian Remote Sensing & Photogrammetry Conference, viewed 4 January 2011, www.scribd.com/doc/37455826/15arspc-Submission-119.
 
+metadata:
+    format:
+        name: NetCDF
+    instrument:
+        name: OLI_TIRS
+    platform:
+        code: LANDSAT_8
+    product_type: fractional_cover
 storage:
   driver: NetCDF CF
 

--- a/fc/fc_app.py
+++ b/fc/fc_app.py
@@ -3,10 +3,12 @@ Entry point for producing Fractional Cover products.
 
 Specifically intended for running in the PBS job queue system at the NCI.
 
-The three entry points are:
-1. datacube-fc submit
-2. datacube-fc generate
-3. datacube-fc run
+Following cli commands are supported:
+1. datacube-fc list
+2. datacube-fc ensure-products
+3. datacube-fc submit
+4. datacube-fc generate
+5. datacube-fc run
 """
 import logging
 import os

--- a/fc/fc_app.py
+++ b/fc/fc_app.py
@@ -124,7 +124,7 @@ def _create_output_definition(config: dict, source_product: DatasetType) -> dict
     output_product_definition['name'] = config['output_product']
     output_product_definition['managed'] = True
     output_product_definition['description'] = config['description']
-    output_product_definition['metadata']['format'] = {'name': 'NetCDF'}
+    output_product_definition['metadata']['format'] = {'name': config['storage']['driver']}
     output_product_definition['metadata']['product_type'] = config.get('product_type', 'fractional_cover')
     output_product_definition['storage'] = {
         k: v for (k, v) in config['storage'].items()

--- a/fc/fc_app.py
+++ b/fc/fc_app.py
@@ -113,7 +113,7 @@ def _ensure_products(app_config: dict, index: Index, dry_run: bool) -> Tuple[Dat
     )
     if not dry_run:
         _LOG.info('Add the output product definition for %s in the database.', output_product.name)
-
+        _LOG.error(str(output_product.metadata_doc))
         output_product = index.products.add(output_product)
     return source_product, output_product
 
@@ -123,7 +123,7 @@ def _create_output_definition(config: dict, source_product: DatasetType) -> dict
     output_product_definition['name'] = config['output_product']
     output_product_definition['managed'] = True
     output_product_definition['description'] = config['description']
-    output_product_definition['metadata']['format'] = {'name': config['storage']['driver']}
+    output_product_definition['metadata']['format'] = {'name': 'NetCDF'}
     output_product_definition['metadata']['product_type'] = config.get('product_type', 'fractional_cover')
     output_product_definition['storage'] = {
         k: v for (k, v) in config['storage'].items()

--- a/fc/fc_app.py
+++ b/fc/fc_app.py
@@ -115,7 +115,6 @@ def _ensure_products(app_config: dict, index: Index, dry_run: bool) -> Tuple[Dat
     )
     if not dry_run:
         _LOG.info('Add the output product definition for %s in the database.', output_product.name)
-        _LOG.error(str(output_product.metadata_doc))
         output_product = index.products.add(output_product)
     return source_product, output_product
 


### PR DESCRIPTION
### **Reason for this pull request**
Fractional cover application depends on metadata storage format name in the source product definition to match with that of product config. 

Once test database is setup and `nbart` products are ingested, any attempt to apply `fractional cover` on ingested `nbart` products would raise source and new product definition document mismatch.
```
2019-05-25 00:35:38,187 31138 datacube.ui.click DEBUG Connected to datacube index: Index<db=PostgresDb<engine=Engine(postgresql://sm9911@agdcdev-db.nci.org.au:6432/nci_envtest_db)>>
2019-05-25 00:35:38,636 31138 /g/data/v10/public/modules/dea/20190524/lib/python3.6/site-packages/fc/fc_app.py INFO Add the output product definition for ls8_fc_albers in the database.
Traceback (most recent call last):
  File "/g/data/v10/public/modules/dea/20190524/bin/datacube-fc", line 11, in <module>
    load_entry_point('fc==1.2.9+46.g89d6fce', 'console_scripts', 'datacube-fc')()
  File "/g/data/v10/public/modules/dea-env/20190522/lib/python3.6/site-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/g/data/v10/public/modules/dea-env/20190522/lib/python3.6/site-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/g/data/v10/public/modules/dea-env/20190522/lib/python3.6/site-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/g/data/v10/public/modules/dea-env/20190522/lib/python3.6/site-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/g/data/v10/public/modules/dea-env/20190522/lib/python3.6/site-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/g/data/v10/public/modules/dea/20190524/lib/python3.6/site-packages/datacube/ui/click.py", line 188, in new_func
    return f(parsed_config, *args, **kwargs)
  File "/g/data/v10/public/modules/dea/20190524/lib/python3.6/site-packages/datacube/ui/click.py", line 216, in with_index
    return f(index, *args, **kwargs)
  File "/g/data/v10/public/modules/dea/20190524/lib/python3.6/site-packages/fc/fc_app.py", line 345, in ensure_products
    _, out_product = _ensure_products(app_config_file, index, dry_run)
  File "/g/data/v10/public/modules/dea/20190524/lib/python3.6/site-packages/fc/fc_app.py", line 117, in _ensure_products
    output_product = index.products.add(output_product)
  File "/g/data/v10/public/modules/dea/20190524/lib/python3.6/site-packages/datacube/index/_products.py", line 92, in add
    'Metadata Type {}'.format(product.name)
  File "/g/data/v10/public/modules/dea/20190524/lib/python3.6/site-packages/datacube/utils/changes.py", line 132, in check_doc_unchanged
    ', '.join(['{}: {!r}!={!r}'.format('.'.join(map(str, offset)), v1, v2) for offset, v1, v2 in changes])
datacube.utils.changes.DocumentMismatchError: Metadata Type ls8_fc_albers differs from stored (metadata.format.name: 'NetCDF'!='NetCDF CF')
```

### **Proposed solution**
Add metadata format name in to product config files