### PR TITLE
Correction for USGS C2 scaling

### DIFF
--- a/fc/virtualproduct.py
+++ b/fc/virtualproduct.py
@@ -102,8 +102,7 @@ class FakeFractionalCover(FractionalCover):
 
 def scale_usgs_collection2(data):
     return data.apply(scale_and_clip_dataarray, keep_attrs=True,
-                      scale_factor=2.75, add_offset=-2000, clip_range=(0, 10000))
-
+                      scale_factor=0.275, add_offset=-2000, clip_range=(0, 10000))
 
 def scale_and_clip_dataarray(dataarray: xr.DataArray, *, scale_factor=1, add_offset=0, clip_range=None,
                              new_nodata=-999, new_dtype='int16'):


### PR DESCRIPTION
The USGS c2 scaling in `virtual_product.py` was changed to be in line with WOfS - so 2.75 becomes 0.275.