### PR TITLE
Fix ls8 fc

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -50,7 +50,7 @@ jobs:
       - name: Install from local dir
         # Don't install the wheel, getting code coverage from tests is nigh on impossible
         run: |
-          python setup.py develop
+          python setup.py develop --no-deps
       - name: Check code
         run: |
           pip freeze

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ 3.6, 3.8, 3.9 ]
+        python-version: [ 3.8, 3.9 ]
     name: Python ${{ matrix.python-version }}
     defaults:
       run:
@@ -39,7 +39,7 @@ jobs:
       - name: Install conda dependencies
         run: |
           mamba install datacube gdal pycodestyle pylint pytest-cov pytest numexpr lxml pydash python-rapidjson \
-          lxml pydash python-rapidjson ruamel.yaml structlog ciso8601 cattrs boltons dawg platformdirs=2.4.0
+          lxml pydash python-rapidjson ruamel.yaml structlog ciso8601 cattrs boltons dawg
           # gdal is required by digitalearthau??
       - name: Install pip deps
         run: |

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -39,7 +39,7 @@ jobs:
       - name: Install conda dependencies
         run: |
           mamba install datacube gdal pycodestyle pylint pytest-cov pytest numexpr lxml pydash python-rapidjson \
-          lxml pydash python-rapidjson ruamel.yaml structlog ciso8601 cattrs boltons dawg
+          lxml pydash python-rapidjson ruamel.yaml structlog ciso8601 cattrs boltons dawg platformdirs=2.4.0
           # gdal is required by digitalearthau??
       - name: Install pip deps
         run: |

--- a/fc/fractional_cover.py
+++ b/fc/fractional_cover.py
@@ -48,8 +48,7 @@ def fractional_cover(
     measurements: Sequence[Measurement] = None,
     regression_coefficients: Mapping[str, Sequence[int]] = None,
     clip_after_regression: bool = False,
-    fc_coefficients: Mapping[str, Sequence[int]] = None)
-) -> xarray.Dataset:
+    fc_coefficients: Mapping[str, Sequence[int]] = None) -> xarray.Dataset:
     """
     Given a tile of spectral observations compute the fractional components.
     The data should be a 2D array
@@ -155,7 +154,7 @@ def compute_fractions(nbar, regression_coefficients, fc_coefficients, clip_after
         return out
     else:
         return _compute_fractions(
-            nbar, regression_coefficients, clip_after_regression=clip_after_regression
+            nbar, regression_coefficients, fc_coefficients, clip_after_regression=clip_after_regression
         )
 
 

--- a/fc/fractional_cover.py
+++ b/fc/fractional_cover.py
@@ -200,9 +200,9 @@ def _compute_fractions(nbar, regression_coefficients, fc_coefficients, clip_afte
     
     # apply fix on ls8 results
     if fc_coefficients is not None:
-        green = apply_coefficients_for_band(green, 'pv', fc_coefficients)
-        dead = apply_coefficients_for_band(dead, 'npv', fc_coefficients)
-        bare = apply_coefficients_for_band(bare, 'bs', fc_coefficients)
+        green = _apply_coefficients_for_band(green, 'pv', fc_coefficients)
+        dead = _apply_coefficients_for_band(dead, 'npv', fc_coefficients)
+        bare = _apply_coefficients_for_band(bare, 'bs', fc_coefficients)
     
     # clip the range to (0, 100)
     numpy.clip(green, a_min=0, a_max=127, out=green)

--- a/fc/fractional_cover.py
+++ b/fc/fractional_cover.py
@@ -48,7 +48,7 @@ def fractional_cover(
     measurements: Sequence[Measurement] = None,
     regression_coefficients: Mapping[str, Sequence[int]] = None,
     clip_after_regression: bool = False,
-    fc_coefficients: Mapping[str, Sequence[int]] = None) -> xarray.Dataset:
+    output_regression_coefficients: Mapping[str, Sequence[int]] = None) -> xarray.Dataset:
     """
     Given a tile of spectral observations compute the fractional components.
     The data should be a 2D array
@@ -73,7 +73,7 @@ def fractional_cover(
         A dictionary with six pairs of coefficients to apply to the green, red, nir, swir1 and swir2 values
         (blue is not used)
     
-    :param fc_coefficients:
+    :param output_regression_coefficients:
         A dictionary with 3 pairs of regression coeficients (intercept, scale) to apply to the bs, pv and npv
         of ls8 after unmixing
 
@@ -101,7 +101,7 @@ def fractional_cover(
     nbar = nbar.where(is_valid_array, no_data)
 
     output_data = compute_fractions(
-        nbar.data, regression_coefficients, fc_coefficients, clip_after_regression=clip_after_regression
+        nbar.data, regression_coefficients, output_regression_coefficients, clip_after_regression=clip_after_regression
     )
     error_val = -1
     where = (
@@ -127,7 +127,7 @@ def fractional_cover(
 
 
 #: pylint: disable=too-many-locals
-def compute_fractions(nbar, regression_coefficients, fc_coefficients, clip_after_regression=False):
+def compute_fractions(nbar, regression_coefficients, output_regression_coefficients, clip_after_regression=False):
     """
     Compute the fractional cover of the given imagery tile
 
@@ -138,7 +138,7 @@ def compute_fractions(nbar, regression_coefficients, fc_coefficients, clip_after
         compute_fractions_with_regs = partial(
             _compute_fractions,
             regression_coefficients=regression_coefficients,
-            fc_coefficients=fc_coefficients,
+            output_regression_coefficients=output_regression_coefficients,
             clip_after_regression=clip_after_regression,
         )
         # The _compute_fractions func will change the band (first) dim from 5 to 4
@@ -154,12 +154,12 @@ def compute_fractions(nbar, regression_coefficients, fc_coefficients, clip_after
         return out
     else:
         return _compute_fractions(
-            nbar, regression_coefficients, fc_coefficients, clip_after_regression=clip_after_regression
+            nbar, regression_coefficients, output_regression_coefficients, clip_after_regression=clip_after_regression
         )
 
 
 #: pylint: disable=too-many-locals
-def _compute_fractions(nbar, regression_coefficients, fc_coefficients, clip_after_regression=False):
+def _compute_fractions(nbar, regression_coefficients, output_regression_coefficients, clip_after_regression=False):
     temp_arr = _make_temp_array(nbar)
 
     sum_to_one_weight = endmembers.sum_weight()
@@ -199,17 +199,17 @@ def _compute_fractions(nbar, regression_coefficients, fc_coefficients, clip_afte
     err = numexpr.evaluate("err")
     
     # apply fix on ls8 results
-    if fc_coefficients is not None:
-        green = _apply_coefficients_for_band(green, 'pv', fc_coefficients)
-        dead = _apply_coefficients_for_band(dead, 'npv', fc_coefficients)
-        bare = _apply_coefficients_for_band(bare, 'bs', fc_coefficients)
+    if output_regression_coefficients is not None:
+        green = _apply_coefficients_for_band(green, 'pv', output_regression_coefficients)
+        dead = _apply_coefficients_for_band(dead, 'npv', output_regression_coefficients)
+        bare = _apply_coefficients_for_band(bare, 'bs', output_regression_coefficients)
     
-    # clip the range to (0, 100)
+    # clip the range to (0, 127)
     numpy.clip(green, a_min=0, a_max=127, out=green)
     numpy.clip(dead, a_min=0, a_max=127, out=dead)
     numpy.clip(bare, a_min=0, a_max=127, out=bare)
     numpy.clip(err, a_min=0, a_max=127, out=err)
-    
+
     output_data = numpy.array([green, dead, bare, err], dtype=numpy.int8)
     output_data[:, wh_unmix_err] = -1
 

--- a/fc/fractional_cover.py
+++ b/fc/fractional_cover.py
@@ -48,6 +48,7 @@ def fractional_cover(
     measurements: Sequence[Measurement] = None,
     regression_coefficients: Mapping[str, Sequence[int]] = None,
     clip_after_regression: bool = False,
+    fc_coefficients: Mapping[str, Sequence[int]] = None)
 ) -> xarray.Dataset:
     """
     Given a tile of spectral observations compute the fractional components.
@@ -72,6 +73,10 @@ def fractional_cover(
     :param regression_coefficients:
         A dictionary with six pairs of coefficients to apply to the green, red, nir, swir1 and swir2 values
         (blue is not used)
+    
+    :param fc_coefficients:
+        A dictionary with 3 pairs of regression coeficients (intercept, scale) to apply to the bs, pv and npv
+        of ls8 after unmixing
 
     :return:
         An xarray.Dataset containing:
@@ -97,7 +102,7 @@ def fractional_cover(
     nbar = nbar.where(is_valid_array, no_data)
 
     output_data = compute_fractions(
-        nbar.data, regression_coefficients, clip_after_regression=clip_after_regression
+        nbar.data, regression_coefficients, fc_coefficients, clip_after_regression=clip_after_regression
     )
     error_val = -1
     where = (
@@ -123,7 +128,7 @@ def fractional_cover(
 
 
 #: pylint: disable=too-many-locals
-def compute_fractions(nbar, regression_coefficients, clip_after_regression=False):
+def compute_fractions(nbar, regression_coefficients, fc_coefficients, clip_after_regression=False):
     """
     Compute the fractional cover of the given imagery tile
 
@@ -134,6 +139,7 @@ def compute_fractions(nbar, regression_coefficients, clip_after_regression=False
         compute_fractions_with_regs = partial(
             _compute_fractions,
             regression_coefficients=regression_coefficients,
+            fc_coefficients=fc_coefficients,
             clip_after_regression=clip_after_regression,
         )
         # The _compute_fractions func will change the band (first) dim from 5 to 4
@@ -154,7 +160,7 @@ def compute_fractions(nbar, regression_coefficients, clip_after_regression=False
 
 
 #: pylint: disable=too-many-locals
-def _compute_fractions(nbar, regression_coefficients, clip_after_regression=False):
+def _compute_fractions(nbar, regression_coefficients, fc_coefficients, clip_after_regression=False):
     temp_arr = _make_temp_array(nbar)
 
     sum_to_one_weight = endmembers.sum_weight()
@@ -186,19 +192,25 @@ def _compute_fractions(nbar, regression_coefficients, clip_after_regression=Fals
         "(green == -10) |" "(dead1 == -10) |" "(dead2 == -10) |" "(bare == -10)"
     )
 
-    # scale the results and clip the range to (0, 100)
+
+    # scale the results
     green = numexpr.evaluate("green / 0.01")
-    numpy.clip(green, a_min=0, a_max=127, out=green)
-
     dead = numexpr.evaluate("(dead1 + dead2) / 0.01")
-    numpy.clip(dead, a_min=0, a_max=127, out=dead)
-
     bare = numexpr.evaluate("bare / 0.01")
-    numpy.clip(bare, a_min=0, a_max=127, out=bare)
-
     err = numexpr.evaluate("err")
+    
+    # apply fix on ls8 results
+    if fc_coefficients is not None:
+        green = apply_coefficients_for_band(green, 'pv', fc_coefficients)
+        dead = apply_coefficients_for_band(dead, 'npv', fc_coefficients)
+        bare = apply_coefficients_for_band(bare, 'bs', fc_coefficients)
+    
+    # clip the range to (0, 100)
+    numpy.clip(green, a_min=0, a_max=127, out=green)
+    numpy.clip(dead, a_min=0, a_max=127, out=dead)
+    numpy.clip(bare, a_min=0, a_max=127, out=bare)
     numpy.clip(err, a_min=0, a_max=127, out=err)
-
+    
     output_data = numpy.array([green, dead, bare, err], dtype=numpy.int8)
     output_data[:, wh_unmix_err] = -1
 

--- a/fc/virtualproduct.py
+++ b/fc/virtualproduct.py
@@ -21,13 +21,13 @@ class FractionalCover(Transformation):
     def __init__(
         self,
         regression_coefficients=None,
-        fc_coefficients=None,
+        output_regression_coefficients=None,
         c2_scaling=False,
         test_mode=False,
         clip_after_regression=False,
     ):
         self.regression_coefficients = regression_coefficients
-        self.fc_coefficients = fc_coefficients
+        self.output_regression_coefficients = output_regression_coefficients
         self.c2_scaling = c2_scaling
         self.test_mode = test_mode
         self.clip_after_regression = clip_after_regression
@@ -52,7 +52,7 @@ class FractionalCover(Transformation):
                     data.isel(time=time_idx),
                     self.measurements,
                     self.regression_coefficients,
-                    self.fc_coefficients,
+                    self.output_regression_coefficients,
                     clip_after_regression=self.clip_after_regression
                 )
             )
@@ -72,7 +72,7 @@ class FractionalCover(Transformation):
                 "repo_url": "https://github.com/GeoscienceAustralia/fc.git",
                 "parameters": {
                     "regression_coefficients": self.regression_coefficients,
-                    'fc_coefficients': self.fc_coefficients,
+                    'output_regression_coefficients': self.output_regression_coefficients,
                     "usgs_c2_scaling": self.c2_scaling,
                 },
             }

--- a/fc/virtualproduct.py
+++ b/fc/virtualproduct.py
@@ -21,11 +21,13 @@ class FractionalCover(Transformation):
     def __init__(
         self,
         regression_coefficients=None,
+        fc_coefficients=None,
         c2_scaling=False,
         test_mode=False,
         clip_after_regression=False,
     ):
         self.regression_coefficients = regression_coefficients
+        self.fc_coefficients = fc_coefficients
         self.c2_scaling = c2_scaling
         self.test_mode = test_mode
         self.clip_after_regression = clip_after_regression
@@ -50,6 +52,7 @@ class FractionalCover(Transformation):
                     data.isel(time=time_idx),
                     self.measurements,
                     self.regression_coefficients,
+                    self.fc_coefficients,
                     clip_after_regression=self.clip_after_regression
                 )
             )
@@ -69,6 +72,7 @@ class FractionalCover(Transformation):
                 "repo_url": "https://github.com/GeoscienceAustralia/fc.git",
                 "parameters": {
                     "regression_coefficients": self.regression_coefficients,
+                    'fc_coefficients': self.fc_coefficients,
                     "usgs_c2_scaling": self.c2_scaling,
                 },
             }

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
     data_files=[
         ('fc/config/', config_files)],
     classifiers=[
-        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.8',
     ],
     install_requires=[
         'numpy',

--- a/tests/test_fractional_cover.py
+++ b/tests/test_fractional_cover.py
@@ -17,6 +17,7 @@ def test_fc_with_regression(sr_filepath, fc_filepath):
     fc_coefficients = {'pv': [2.77, 0.9481], 'bs': [2.45, 0.9499], 'npv': [-0.73, 0.9578]}
     sr_dataset = open_dataset(sr_filepath)
     fc_dataset = fractional_cover(sr_dataset, DEFAULT_MEASUREMENTS, fc_coefficients=fc_coefficients)
+
     validation_ds = open_dataset(fc_filepath)
     for var in validation_ds.data_vars:
         if var.lower() != "ue":

--- a/tests/test_fractional_cover.py
+++ b/tests/test_fractional_cover.py
@@ -13,6 +13,18 @@ from fc.fractional_cover import (DEFAULT_MEASUREMENTS, LANDSAT_8_COEFFICIENTS,
                                  _apply_coefficients_for_band, fractional_cover)
 
 
+def test_fc_with_regression(sr_filepath, fc_filepath):
+    fc_coefficients = {'pv': [2.77, 0.9481], 'bs': [2.45, 0.9499], 'npv': [-0.73, 0.9578]}
+    sr_dataset = open_dataset(sr_filepath)
+    fc_dataset = fractional_cover(sr_dataset, DEFAULT_MEASUREMENTS, fc_coefficients=fc_coefficients)
+    validation_ds = open_dataset(fc_filepath)
+    for var in validation_ds.data_vars:
+        if var.lower() != "ue":
+            validation_ds[var].data = (validation_ds[var] * fc_coefficients[var.lower()][1]
+                                       + fc_coefficients[var.lower()][0]).clip(min=0).data
+    assert validation_ds == fc_dataset
+
+
 def test_coefficients():
     data = np.zeros((10, 10))
     data_tweaked = _apply_coefficients_for_band(data, 'swir2', LANDSAT_8_COEFFICIENTS, clip_after_regression=True)

--- a/tests/test_fractional_cover.py
+++ b/tests/test_fractional_cover.py
@@ -14,15 +14,16 @@ from fc.fractional_cover import (DEFAULT_MEASUREMENTS, LANDSAT_8_COEFFICIENTS,
 
 
 def test_fc_with_regression(sr_filepath, fc_filepath):
-    fc_coefficients = {'pv': [2.77, 0.9481], 'bs': [2.45, 0.9499], 'npv': [-0.73, 0.9578]}
+    output_regression_coefficients = {'pv': [2.77, 0.9481], 'bs': [2.45, 0.9499], 'npv': [-0.73, 0.9578]}
     sr_dataset = open_dataset(sr_filepath)
-    fc_dataset = fractional_cover(sr_dataset, DEFAULT_MEASUREMENTS, fc_coefficients=fc_coefficients)
+    fc_dataset = fractional_cover(sr_dataset, DEFAULT_MEASUREMENTS,
+                                  output_regression_coefficients=output_regression_coefficients)
 
     validation_ds = open_dataset(fc_filepath)
     for var in validation_ds.data_vars:
         if var.lower() != "ue":
-            validation_ds[var].data = (validation_ds[var] * fc_coefficients[var.lower()][1]
-                                       + fc_coefficients[var.lower()][0]).clip(min=0).data
+            validation_ds[var].data = (validation_ds[var] * output_regression_coefficients[var.lower()][1]
+                                       + output_regression_coefficients[var.lower()][0]).clip(min=0).data
     assert validation_ds == fc_dataset
 
 


### PR DESCRIPTION
Apply a group of linear regression coefficients on ls8 fc unmixing results, such that ls8 fc can be close to ls7 fc enough.

Sorry if you don't like the name `fc_coefficients`, tried my best in naming things and willing to accept any other suggestion.

It shouldn't affect any current thing if leaving out `fc_coefficients`, which is only intended to fix the difference we observed in dea fc product. 