### PR TITLE
Fix up USGS scaling and coefficient application that result in negative numbers

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -64,16 +64,14 @@ jobs:
           name: packages
           path: dist
 
-      - uses: codecov/codecov-action@v1
+      - uses: codecov/codecov-action@v2
         with:
           env_vars: OS,PYTHON
-          file: ./coverage.xml
+          files: ./coverage.xml
+          fail_ci_if_error: false
 
   deploy-packages:
-#   deploy:
-#       if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     if: startsWith(github.ref, 'refs/tags/')
-#    if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     needs: test
     steps:

--- a/fc/fractional_cover.py
+++ b/fc/fractional_cover.py
@@ -186,6 +186,9 @@ def apply_coefficients_for_band(numpyarray, band, regression_coefficients):
     coefficient0 = band_coefficients[0]  # noqa: F841
     coefficient1 = band_coefficients[1]  # noqa: F841
     numpyarray = numexpr.evaluate('coefficient0 + (coefficient1 * numpyarray)')
+    # Ensure that coeffiecient application doesn't result in negative values
+    # Values here should still be between 0 and 10,000
+    numpy.clip(numpyarray, a_min=0, a_max=10000, out=numpyarray)
     return numpyarray
 
 

--- a/fc/fractional_cover.py
+++ b/fc/fractional_cover.py
@@ -25,12 +25,22 @@ try:
 except ImportError:
     raise Exception('ERROR: Fortran unmixing cannot be loaded.')
 
-DEFAULT_MEASUREMENTS = [{
-    'name': 'PV',
-    'dtype': 'int8',
-    'nodata': -1,
-    'units': 'percent'
-}]
+DEFAULT_MEASUREMENTS = [
+    Measurement(name='PV', dtype='int8', nodata=-1, units='percent'),
+    Measurement(name='NPV', dtype='int8', nodata=-1, units='percent'),
+    Measurement(name='BS', dtype='int8', nodata=-1, units='percent'),
+    Measurement(name='UE', dtype='int8', nodata=-1, units='1'),
+]
+
+# From table 2 in http://www.mdpi.com/2072-4292/6/9/7952/htm, scaled to 0-10,000 instead of 0-1
+LANDSAT_8_COEFFICIENTS = {
+    "blue": [4.1, 0.97470],
+    "green": [28.9, 0.99779],
+    "red": [27.4, 1.00446],
+    "nir": [0.4, 0.98906],
+    "swir1": [25.6, 0.99467],
+    "swir2": [-32.7, 1.02551]
+}
 
 
 def fractional_cover(nbar_tile: xarray.Dataset,

--- a/fc/fractional_cover.py
+++ b/fc/fractional_cover.py
@@ -1,10 +1,9 @@
 from functools import partial
-from typing import Sequence, Mapping
+from typing import Mapping, Sequence
 
 import numexpr
 import numpy
 import xarray
-
 from datacube.model import Measurement
 
 try:
@@ -15,37 +14,41 @@ except ImportError:  # pragma: no cover
     dask_array_type = ()
 
 from datacube import Datacube
-from datacube.utils.masking import valid_data_mask
 from datacube.utils import iter_slices
+from datacube.utils.masking import valid_data_mask
 
 from . import endmembers
 
 try:
     from .unmix import unmiximage
 except ImportError:
-    raise Exception('ERROR: Fortran unmixing cannot be loaded.')
+    raise Exception("ERROR: Fortran unmixing cannot be loaded.")
 
 DEFAULT_MEASUREMENTS = [
-    Measurement(name='PV', dtype='int8', nodata=-1, units='percent'),
-    Measurement(name='NPV', dtype='int8', nodata=-1, units='percent'),
-    Measurement(name='BS', dtype='int8', nodata=-1, units='percent'),
-    Measurement(name='UE', dtype='int8', nodata=-1, units='1'),
+    Measurement(name="PV", dtype="int8", nodata=-1, units="percent"),
+    Measurement(name="NPV", dtype="int8", nodata=-1, units="percent"),
+    Measurement(name="BS", dtype="int8", nodata=-1, units="percent"),
+    Measurement(name="UE", dtype="int8", nodata=-1, units="1"),
 ]
 
-# From table 2 in http://www.mdpi.com/2072-4292/6/9/7952/htm, scaled to 0-10,000 instead of 0-1
+# From table 2 in http://www.mdpi.com/2072-4292/6/9/7952/htm, the first param is
+# scaled to 0-10,000 instead of 0-1
 LANDSAT_8_COEFFICIENTS = {
     "blue": [4.1, 0.97470],
     "green": [28.9, 0.99779],
     "red": [27.4, 1.00446],
     "nir": [0.4, 0.98906],
     "swir1": [25.6, 0.99467],
-    "swir2": [-32.7, 1.02551]
+    "swir2": [-32.7, 1.02551],
 }
 
 
-def fractional_cover(nbar_tile: xarray.Dataset,
-                     measurements: Sequence[Measurement] = None,
-                     regression_coefficients: Mapping[str, Sequence[int]] = None) -> xarray.Dataset:
+def fractional_cover(
+    nbar_tile: xarray.Dataset,
+    measurements: Sequence[Measurement] = None,
+    regression_coefficients: Mapping[str, Sequence[int]] = None,
+    clip_after_regression: bool = False,
+) -> xarray.Dataset:
     """
     Given a tile of spectral observations compute the fractional components.
     The data should be a 2D array
@@ -84,28 +87,34 @@ def fractional_cover(nbar_tile: xarray.Dataset,
         measurements = DEFAULT_MEASUREMENTS
 
     # Ensure the bands are all there and in the right order
-    nbar_tile = nbar_tile[['green', 'red', 'nir', 'swir1', 'swir2']]
+    nbar_tile = nbar_tile[["green", "red", "nir", "swir1", "swir2"]]
 
     # Set nodata to 0
     no_data = 0
-    is_valid_array = valid_data_mask(nbar_tile).to_array(dim='band').all(dim='band')
+    is_valid_array = valid_data_mask(nbar_tile).to_array(dim="band").all(dim="band")
 
-    nbar = nbar_tile.to_array(dim='band')
+    nbar = nbar_tile.to_array(dim="band")
     nbar = nbar.where(is_valid_array, no_data)
 
-    output_data = compute_fractions(nbar.data, regression_coefficients)
+    output_data = compute_fractions(
+        nbar.data, regression_coefficients, clip_after_regression=clip_after_regression
+    )
     error_val = -1
-    where = numpy.where if not isinstance(output_data, dask_array_type) else dask.array.where
+    where = (
+        numpy.where
+        if not isinstance(output_data, dask_array_type)
+        else dask.array.where
+    )
 
     def data_func(measurement, *args, **kwargs):
-        band_names = ['PV', 'NPV', 'BS', 'UE']
-        src_var = measurement.get('src_var', None) or measurement.get('name')
+        band_names = ["PV", "NPV", "BS", "UE"]
+        src_var = measurement.get("src_var", None) or measurement.get("name")
         i = band_names.index(src_var.upper())
         unmasked_var = output_data[i]
 
         # Set nodata value into output array
-        band_nodata = numpy.dtype(measurement['dtype']).type(measurement['nodata'])
-        no_error = (unmasked_var != error_val)
+        band_nodata = numpy.dtype(measurement["dtype"]).type(measurement["nodata"])
+        no_error = unmasked_var != error_val
         return where(is_valid_array.data & no_error, unmasked_var, band_nodata)
 
     dataset = Datacube.create_storage({}, nbar_tile.geobox, measurements, data_func)
@@ -113,15 +122,8 @@ def fractional_cover(nbar_tile: xarray.Dataset,
     return dataset
 
 
-def make_temp_array(nbar):
-    geo_shape = nbar.shape[1:]
-    temp_vars = ['green', 'dead1', 'dead2', 'bare', 'err']
-    temp_shape = (len(temp_vars),) + geo_shape
-    return numpy.empty(temp_shape, dtype=numpy.float)
-
-
 #: pylint: disable=too-many-locals
-def compute_fractions(nbar, regression_coefficients):
+def compute_fractions(nbar, regression_coefficients, clip_after_regression=False):
     """
     Compute the fractional cover of the given imagery tile
 
@@ -129,20 +131,31 @@ def compute_fractions(nbar, regression_coefficients):
     :return (numpy.array, numpy_array): Output array of [green, dead, bare] * (x, y), and the unmix error array
     """
     if isinstance(nbar, dask_array_type):
-        compute_fractions_with_regs = partial(_compute_fractions, regression_coefficients=regression_coefficients)
+        compute_fractions_with_regs = partial(
+            _compute_fractions,
+            regression_coefficients=regression_coefficients,
+            clip_after_regression=clip_after_regression,
+        )
         # The _compute_fractions func will change the band (first) dim from 5 to 4
         new_chunks = ((4,),) + nbar.chunks[1:]
         # Apply the function to very x/y tile in the dask array
         # We need all bands for the calculation, so rechunk so they are in the same chunk
-        out = dask.array.map_blocks(compute_fractions_with_regs, nbar.rechunk({0: -1}), chunks=new_chunks, dtype='int8')
+        out = dask.array.map_blocks(
+            compute_fractions_with_regs,
+            nbar.rechunk({0: -1}),
+            chunks=new_chunks,
+            dtype="int8",
+        )
         return out
     else:
-        return _compute_fractions(nbar, regression_coefficients)
+        return _compute_fractions(
+            nbar, regression_coefficients, clip_after_regression=clip_after_regression
+        )
 
 
 #: pylint: disable=too-many-locals
-def _compute_fractions(nbar, regression_coefficients):
-    temp_arr = make_temp_array(nbar)
+def _compute_fractions(nbar, regression_coefficients, clip_after_regression=False):
+    temp_arr = _make_temp_array(nbar)
 
     sum_to_one_weight = endmembers.sum_weight()
     endmembers_array = endmembers.get_endmembers(sum_to_one_weight)
@@ -154,16 +167,24 @@ def _compute_fractions(nbar, regression_coefficients):
     for geo_index in iter_slices(nbar.shape[1:], chunk_size):
         index = band_index + geo_index
         arr = nbar[index]
-        temp_arr[index] = unmix(arr[0], arr[1], arr[2], arr[3], arr[4], sum_to_one_weight, endmembers_array,
-                                regression_coefficients)
+        temp_arr[index] = unmix(
+            arr[0],
+            arr[1],
+            arr[2],
+            arr[3],
+            arr[4],
+            sum_to_one_weight,
+            endmembers_array,
+            regression_coefficients,
+            clip_after_regression=clip_after_regression,
+        )
 
     green, dead1, dead2, bare, err = temp_arr
 
     # Find unmixing errors - if an pixel is in error then all pixels for that location are errors
-    wh_unmix_err = numexpr.evaluate("(green == -10) |"
-                                    "(dead1 == -10) |"
-                                    "(dead2 == -10) |"
-                                    "(bare == -10)")
+    wh_unmix_err = numexpr.evaluate(
+        "(green == -10) |" "(dead1 == -10) |" "(dead2 == -10) |" "(bare == -10)"
+    )
 
     # scale the results and clip the range to (0, 100)
     green = numexpr.evaluate("green / 0.01")
@@ -184,26 +205,18 @@ def _compute_fractions(nbar, regression_coefficients):
     return output_data
 
 
-def apply_coefficients_for_band(numpyarray, band, regression_coefficients):
-    """
-    Apply regression coefficients in the form: ETM = c0 + OLI*c1
-    As per table 2 in http://www.mdpi.com/2072-4292/6/9/7952/htm
-    :param numpyarray: array of measurements to apply coefficients to
-    :param band: name of the coefficient pair to apply
-    :return: updated array
-    """
-    band_coefficients = regression_coefficients[band]
-    coefficient0 = band_coefficients[0]  # noqa: F841
-    coefficient1 = band_coefficients[1]  # noqa: F841
-    numpyarray = numexpr.evaluate('coefficient0 + (coefficient1 * numpyarray)')
-    # Ensure that coeffiecient application doesn't result in negative values
-    # Values here should still be between 0 and 10,000
-    numpy.clip(numpyarray, a_min=0, a_max=10000, out=numpyarray)
-    return numpyarray
-
-
 #: pylint: disable=too-many-statements, too-many-locals
-def unmix(green, red, nir, swir1, swir2, sum_to_one_weight, endmembers_array, regression_coefficients):
+def unmix(
+    green,
+    red,
+    nir,
+    swir1,
+    swir2,
+    sum_to_one_weight,
+    endmembers_array,
+    regression_coefficients,
+    clip_after_regression=False,
+):
     """
     NNLS Unmixing v1.0
     Scarth 20090810 14:06:35 CEST
@@ -223,11 +236,36 @@ def unmix(green, red, nir, swir1, swir2, sum_to_one_weight, endmembers_array, re
     """
 
     if regression_coefficients is not None:
-        green = apply_coefficients_for_band(green, 'green', regression_coefficients)
-        red = apply_coefficients_for_band(red, 'red', regression_coefficients)
-        nir = apply_coefficients_for_band(nir, 'nir', regression_coefficients)
-        swir1 = apply_coefficients_for_band(swir1, 'swir1', regression_coefficients)
-        swir2 = apply_coefficients_for_band(swir2, 'swir2', regression_coefficients)
+        green = _apply_coefficients_for_band(
+            green,
+            "green",
+            regression_coefficients,
+            clip_after_regression=clip_after_regression,
+        )
+        red = _apply_coefficients_for_band(
+            red,
+            "red",
+            regression_coefficients,
+            clip_after_regression=clip_after_regression,
+        )
+        nir = _apply_coefficients_for_band(
+            nir,
+            "nir",
+            regression_coefficients,
+            clip_after_regression=clip_after_regression,
+        )
+        swir1 = _apply_coefficients_for_band(
+            swir1,
+            "swir1",
+            regression_coefficients,
+            clip_after_regression=clip_after_regression,
+        )
+        swir2 = _apply_coefficients_for_band(
+            swir2,
+            "swir2",
+            regression_coefficients,
+            clip_after_regression=clip_after_regression,
+        )
 
     band2 = numexpr.evaluate("(1.0 + green) * 0.0001")
     band3 = numexpr.evaluate("(1.0 + red) * 0.0001")
@@ -302,20 +340,75 @@ def unmix(green, red, nir, swir1, swir2, sum_to_one_weight, endmembers_array, re
     band_ratio4 = numexpr.evaluate("(band3 - band2) / (band3 + band2)")
 
     # 2014_07_23 uses 60 endmembers
-    interactive_terms = numpy.array([b2b3, b2b4, b2b5, b2b7, b2lb2, b2lb3, b2lb4, b2lb5, b2lb7,
-                                     b3b4, b3b5, b3b7, b3lb2, b3lb3, b3lb4, b3lb5, b3lb7,
-                                     b4b5, b4b7, b4lb2, b4lb3, b4lb4, b4lb5, b4lb7,
-                                     b5b7, b5lb2, b5lb3, b5lb4, b5lb5, b5lb7,
-                                     b7lb2, b7lb3, b7lb4, b7lb5, b7lb7, lb2lb3,
-                                     lb2lb4, lb2lb5, lb2lb7, lb3lb4, lb3lb5, lb3lb7, lb4lb5, lb4lb7, lb5lb7,
-                                     band2, band3, band4, band5, band7,
-                                     logb2, logb3, logb4, logb5, logb7,
-                                     band_ratio1, band_ratio2, band_ratio3, band_ratio4])
+    interactive_terms = numpy.array(
+        [
+            b2b3,
+            b2b4,
+            b2b5,
+            b2b7,
+            b2lb2,
+            b2lb3,
+            b2lb4,
+            b2lb5,
+            b2lb7,
+            b3b4,
+            b3b5,
+            b3b7,
+            b3lb2,
+            b3lb3,
+            b3lb4,
+            b3lb5,
+            b3lb7,
+            b4b5,
+            b4b7,
+            b4lb2,
+            b4lb3,
+            b4lb4,
+            b4lb5,
+            b4lb7,
+            b5b7,
+            b5lb2,
+            b5lb3,
+            b5lb4,
+            b5lb5,
+            b5lb7,
+            b7lb2,
+            b7lb3,
+            b7lb4,
+            b7lb5,
+            b7lb7,
+            lb2lb3,
+            lb2lb4,
+            lb2lb5,
+            lb2lb7,
+            lb3lb4,
+            lb3lb5,
+            lb3lb7,
+            lb4lb5,
+            lb4lb7,
+            lb5lb7,
+            band2,
+            band3,
+            band4,
+            band5,
+            band7,
+            logb2,
+            logb3,
+            logb4,
+            logb5,
+            logb7,
+            band_ratio1,
+            band_ratio2,
+            band_ratio3,
+            band_ratio4,
+        ]
+    )
 
     # Now add the sum to one constraint to the interactive terms
     # First make a zero array of the right shape
-    weighted_spectra = numpy.zeros((interactive_terms.shape[0] + 1,) +
-                                   interactive_terms.shape[1:])
+    weighted_spectra = numpy.zeros(
+        (interactive_terms.shape[0] + 1,) + interactive_terms.shape[1:]
+    )
     # Insert the interactive terms
     weighted_spectra[:-1, ...] = interactive_terms
     # Last element is special weighting
@@ -324,8 +417,38 @@ def unmix(green, red, nir, swir1, swir2, sum_to_one_weight, endmembers_array, re
     in_null = 0.0001
     out_unmix_null = -10.0
 
-    fractions = unmiximage.unmiximage(weighted_spectra, endmembers_array, in_null, out_unmix_null)
+    fractions = unmiximage.unmiximage(
+        weighted_spectra, endmembers_array, in_null, out_unmix_null
+    )
 
     # gives green, dead1, dead2 and bare fractions
     # the last band should be the unmixing error
     return fractions
+
+
+def _make_temp_array(nbar):
+    geo_shape = nbar.shape[1:]
+    temp_vars = ["green", "dead1", "dead2", "bare", "err"]
+    temp_shape = (len(temp_vars),) + geo_shape
+    return numpy.empty(temp_shape, dtype=numpy.float)
+
+
+def _apply_coefficients_for_band(
+    numpyarray, band, regression_coefficients, clip_after_regression=False
+):
+    """
+    Apply regression coefficients in the form: ETM = c0 + OLI*c1
+    As per table 2 in http://www.mdpi.com/2072-4292/6/9/7952/htm
+    :param numpyarray: array of measurements to apply coefficients to
+    :param band: name of the coefficient pair to apply
+    :return: updated array
+    """
+    band_coefficients = regression_coefficients[band]
+    coefficient0 = band_coefficients[0]  # noqa: F841
+    coefficient1 = band_coefficients[1]  # noqa: F841
+    numpyarray = numexpr.evaluate("coefficient0 + (coefficient1 * numpyarray)")
+    # Ensure that coeffiecient application doesn't result in negative values
+    # Values here should still be between 0 and 10,000
+    if clip_after_regression:
+        numpy.clip(numpyarray, a_min=0, a_max=10000, out=numpyarray)
+    return numpyarray

--- a/fc/virtualproduct.py
+++ b/fc/virtualproduct.py
@@ -1,34 +1,14 @@
 import xarray as xr
+from datacube.virtual import Measurement, Transformation
 
-from datacube.virtual import Transformation, Measurement
 from fc import __version__
 from fc.fractional_cover import fractional_cover
 
 FC_MEASUREMENTS = [
-    {
-        'name': 'pv',
-        'dtype': 'int8',
-        'nodata': -1,
-        'units': 'percent'
-    },
-    {
-        'name': 'npv',
-        'dtype': 'int8',
-        'nodata': -1,
-        'units': 'percent'
-    },
-    {
-        'name': 'bs',
-        'dtype': 'int8',
-        'nodata': -1,
-        'units': 'percent'
-    },
-    {
-        'name': 'ue',
-        'dtype': 'int8',
-        'nodata': -1,
-        'units': ''
-    },
+    {"name": "pv", "dtype": "int8", "nodata": -1, "units": "percent"},
+    {"name": "npv", "dtype": "int8", "nodata": -1, "units": "percent"},
+    {"name": "bs", "dtype": "int8", "nodata": -1, "units": "percent"},
+    {"name": "ue", "dtype": "int8", "nodata": -1, "units": ""},
 ]
 
 
@@ -38,14 +18,17 @@ class FractionalCover(Transformation):
     Requires bands named 'green', 'red', 'nir', 'swir1', 'swir2'
     """
 
-    def __init__(self, regression_coefficients=None, c2_scaling=False, test_mode=False):
-        if regression_coefficients is None:
-            regression_coefficients = {band: [0, 1]
-                                       for band in ['green', 'red', 'nir', 'swir1', 'swir2']
-                                       }
+    def __init__(
+        self,
+        regression_coefficients=None,
+        c2_scaling=False,
+        test_mode=False,
+        clip_after_regression=False,
+    ):
         self.regression_coefficients = regression_coefficients
         self.c2_scaling = c2_scaling
         self.test_mode = test_mode
+        self.clip_after_regression = clip_after_regression
 
     @property
     def measurements(self):
@@ -62,26 +45,34 @@ class FractionalCover(Transformation):
         fc = []
 
         for time_idx in range(len(data.time)):
-            fc.append(fractional_cover(data.isel(time=time_idx), self.measurements, self.regression_coefficients))
-        fc = xr.concat(fc, dim='time')
-        fc.attrs['crs'] = data.attrs['crs']
+            fc.append(
+                fractional_cover(
+                    data.isel(time=time_idx),
+                    self.measurements,
+                    self.regression_coefficients,
+                    clip_after_regression=self.clip_after_regression
+                )
+            )
+        fc = xr.concat(fc, dim="time")
+        fc.attrs["crs"] = data.attrs["crs"]
         try:
-            fc = fc.rename(BS='bs', PV='pv', NPV='npv', UE='ue')
+            fc = fc.rename(BS="bs", PV="pv", NPV="npv", UE="ue")
         except ValueError:  # Assuming the names are already correct and don't need to be changed.
             pass
         return fc
 
     def algorithm_metadata(self):
         return {
-            'algorithm': {
-                'name': 'Fractional Cover',
-                'version': __version__,
-                'repo_url': 'https://github.com/GeoscienceAustralia/fc.git',
-                'parameters': {
-                    'regression_coefficients': self.regression_coefficients,
-                    'usgs_c2_scaling': self.c2_scaling
-                }
-            }}
+            "algorithm": {
+                "name": "Fractional Cover",
+                "version": __version__,
+                "repo_url": "https://github.com/GeoscienceAustralia/fc.git",
+                "parameters": {
+                    "regression_coefficients": self.regression_coefficients,
+                    "usgs_c2_scaling": self.c2_scaling,
+                },
+            }
+        }
 
 
 class FakeFractionalCover(FractionalCover):
@@ -95,15 +86,19 @@ class FakeFractionalCover(FractionalCover):
         if self.c2_scaling:
             # The C2 data need to be scaled
             data = scale_usgs_collection2(data)
-        return xr.Dataset({'pv': data.red,
-                           'bs': data.red,
-                           'npv': data.green},
-                          attrs=data.attrs)
+        return xr.Dataset(
+            {"pv": data.red, "bs": data.red, "npv": data.green}, attrs=data.attrs
+        )
 
 
 def scale_usgs_collection2(data):
-    return data.apply(scale_and_clip_dataarray, keep_attrs=True,
-                      scale_factor=0.275, add_offset=-2000, clip_range=(0, 10000))
+    return data.apply(
+        scale_and_clip_dataarray,
+        keep_attrs=True,
+        scale_factor=0.275,
+        add_offset=-2000,
+        clip_range=(0, 10000),
+    )
 
 
 def scale_and_clip_dataarray(

--- a/fc/virtualproduct.py
+++ b/fc/virtualproduct.py
@@ -47,8 +47,9 @@ class FractionalCover(Transformation):
         self.c2_scaling = c2_scaling
         self.test_mode = test_mode
 
-    def measurements(self, input_measurements):
-        return {m['name']: Measurement(**m) for m in FC_MEASUREMENTS}
+    @property
+    def measurements(self):
+        return [Measurement(**m) for m in FC_MEASUREMENTS]
 
     def compute(self, data):
         if self.test_mode:
@@ -59,9 +60,9 @@ class FractionalCover(Transformation):
             data = scale_usgs_collection2(data)
 
         fc = []
-        measurements = [Measurement(**m) for m in FC_MEASUREMENTS]
+
         for time_idx in range(len(data.time)):
-            fc.append(fractional_cover(data.isel(time=time_idx), measurements, self.regression_coefficients))
+            fc.append(fractional_cover(data.isel(time=time_idx), self.measurements, self.regression_coefficients))
         fc = xr.concat(fc, dim='time')
         fc.attrs['crs'] = data.attrs['crs']
         try:

--- a/fc/virtualproduct.py
+++ b/fc/virtualproduct.py
@@ -104,23 +104,30 @@ def scale_usgs_collection2(data):
     return data.apply(scale_and_clip_dataarray, keep_attrs=True,
                       scale_factor=0.275, add_offset=-2000, clip_range=(0, 10000))
 
-def scale_and_clip_dataarray(dataarray: xr.DataArray, *, scale_factor=1, add_offset=0, clip_range=None,
-                             new_nodata=-999, new_dtype='int16'):
+
+def scale_and_clip_dataarray(
+    dataarray: xr.DataArray,
+    scale_factor=1,
+    add_offset=0,
+    clip_range=None,
+    new_nodata=-999,
+    new_dtype="int16",
+):
     orig_attrs = dataarray.attrs
-    nodata = dataarray.attrs['nodata']
+    nodata = dataarray.attrs["nodata"]
 
     mask = dataarray.data == nodata
 
     dataarray = dataarray * scale_factor + add_offset
 
     if clip_range is not None:
-        clip_min, clip_max = clip_range
-        dataarray.clip(clip_min, clip_max)
+        dataarray = dataarray.clip(*clip_range)
 
     dataarray = dataarray.astype(new_dtype)
 
     dataarray.data[mask] = new_nodata
+
     dataarray.attrs = orig_attrs
-    dataarray.attrs['nodata'] = new_nodata
+    dataarray.attrs["nodata"] = new_nodata
 
     return dataarray

--- a/tests/test_fractional_cover.py
+++ b/tests/test_fractional_cover.py
@@ -10,12 +10,12 @@ import numpy as np
 import xarray as xr
 from fc.fc_app import _get_filename, all_files_exist, tif_filenames
 from fc.fractional_cover import (DEFAULT_MEASUREMENTS, LANDSAT_8_COEFFICIENTS,
-                                 apply_coefficients_for_band, fractional_cover)
+                                 _apply_coefficients_for_band, fractional_cover)
 
 
 def test_coefficients():
     data = np.zeros((10, 10))
-    data_tweaked = apply_coefficients_for_band(data, 'swir2', LANDSAT_8_COEFFICIENTS)
+    data_tweaked = _apply_coefficients_for_band(data, 'swir2', LANDSAT_8_COEFFICIENTS, clip_after_regression=True)
     assert np.all(np.greater_equal(data_tweaked, 0))
 
 


### PR DESCRIPTION
* Scaling was being done, but the resulting array was not being stored, so it wasn't actually being applied
* Coefficients for Landsat 8 can result in negative numbers, which breaks the algorithm. Added a step that clips values to 0-10,000 after applying coefficients
* Minor fixes...

Note, Landsat 8 image that includes regression coefficients but doesn't clip to `0-10,000`:
![image](https://user-images.githubusercontent.com/3445853/145344816-3da3c896-e916-4467-b38d-f6e6c34805a7.png)

And after, which includes clipping from `0-10,000` after applying the regression coefficients:
![image](https://user-images.githubusercontent.com/3445853/145344870-7cf2b565-09e8-4001-aa9e-684bb32fa12b.png)
