### PR TITLE
remove the pin of lower version xarray

### DIFF
--- a/fc/fractional_cover.py
+++ b/fc/fractional_cover.py
@@ -93,9 +93,14 @@ def fractional_cover(
     # Ensure the bands are all there and in the right order
     nbar_tile = nbar_tile[["green", "red", "nir", "swir1", "swir2"]]
 
+    # Check for nodata
+    for var in nbar_tile.data_vars:
+        if nbar_tile[var].attrs.get('nodata') is None:
+            raise ValueError("Band %s has no valid nodata", var)
+
     # Set nodata to 0
-    no_data = 0
     is_valid_array = valid_data_mask(nbar_tile).to_array(dim="band").all(dim="band")
+    no_data = 0
 
     nbar = nbar_tile.to_array(dim="band")
     nbar = nbar.where(is_valid_array, no_data)


### PR DESCRIPTION
The issue:
Currently `alchemist` pin the very low version of `xarray`,  which is unsustainable for maintenance. Ref PR https://github.com/opendatacube/datacube-alchemist/pull/120

The solution:
The only bit marked in the change would potentially affect the computation by the `nodata`, which is highly unlikely though. Selecting variables by names has never caused the loss of `attrs` since `>=0.16.1`. However, `valid_data_mask` expects either a valid `nodata` or `np.nan` in the array, hence I put into the check as the precautious measure when the lower version restrict is removed.
