### PR TITLE
Fix to memory leak in python C / Fortran wrapper

### DIFF
--- a/fc/unmix/unmiximage_wrapper.c
+++ b/fc/unmix/unmiximage_wrapper.c
@@ -37,10 +37,12 @@ static PyObject* py_unmiximage(PyObject* self, PyObject* args) {
     }
 
     // Ensure the image array is Fortran-contiguous (column-major)
+    int new_image_obj = 0;
     if (!PyArray_ISFARRAY(image_obj)) {
         image_obj = (PyArrayObject*) PyArray_FromAny(image_obj,
                                                      PyArray_DescrFromType(NPY_DOUBLE),
                                                      3, 3, NPY_ARRAY_F_CONTIGUOUS, NULL);
+        new_image_obj = 1;
         if (image_obj == NULL) {
             PyErr_SetString(PyExc_ValueError, "Failed to convert image to Fortran-contiguous.");
             return NULL;
@@ -97,15 +99,33 @@ static PyObject* py_unmiximage(PyObject* self, PyObject* args) {
     // Call the Fortran subroutine with the deduced dimensions and input/output arrays
     unmiximage_(image, endMemberMatrix, &numBands, &numEndMembers, &numRows, &numCols, &inNull, &outNull, fractionsImage);
 
+    if (new_image_obj) {
+        Py_DECREF(image_obj);
+    }
+
     // Convert array to c-contiguous before return
     if (!PyArray_ISCARRAY(fractionsImage_obj)) {
-        fractionsImage_obj = (PyArrayObject*) PyArray_FromArray(fractionsImage_obj,
+        PyArrayObject* temp = (PyArrayObject*) PyArray_FromArray(
+            fractionsImage_obj,
+            PyArray_DescrFromType(NPY_DOUBLE),
+            NPY_ARRAY_C_CONTIGUOUS);
+
+        if (temp == NULL) {
+            PyErr_SetString(PyExc_ValueError, "Failed to convert fractionsImage to C-contiguous.");
+            Py_DECREF(fractionsImage_obj);  // Clean up original
+            return NULL;
+        }
+
+        Py_DECREF(fractionsImage_obj);  // Drop reference to original Fortran array
+        fractionsImage_obj = temp;      // Assign the new one
+
+/*        fractionsImage_obj = (PyArrayObject*) PyArray_FromArray(fractionsImage_obj,
                                                                   PyArray_DescrFromType(NPY_DOUBLE),
                                                                   NPY_ARRAY_C_CONTIGUOUS);
         if (!fractionsImage_obj) {
             PyErr_SetString(PyExc_ValueError, "Failed to convert fractionsImage to C-contiguous.");
             return NULL;
-        }
+        } */
     }
 
     return PyArray_Return(fractionsImage_obj);

--- a/fc/unmix/unmiximage_wrapper.c
+++ b/fc/unmix/unmiximage_wrapper.c
@@ -42,6 +42,7 @@ static PyObject* py_unmiximage(PyObject* self, PyObject* args) {
         image_obj = (PyArrayObject*) PyArray_FromAny(image_obj,
                                                      PyArray_DescrFromType(NPY_DOUBLE),
                                                      3, 3, NPY_ARRAY_F_CONTIGUOUS, NULL);
+        // track if image_obj was replaced, so we can clean up later
         new_image_obj = 1;
         if (image_obj == NULL) {
             PyErr_SetString(PyExc_ValueError, "Failed to convert image to Fortran-contiguous.");
@@ -99,6 +100,7 @@ static PyObject* py_unmiximage(PyObject* self, PyObject* args) {
     // Call the Fortran subroutine with the deduced dimensions and input/output arrays
     unmiximage_(image, endMemberMatrix, &numBands, &numEndMembers, &numRows, &numCols, &inNull, &outNull, fractionsImage);
 
+    // Remove our reference to image_obj
     if (new_image_obj) {
         Py_DECREF(image_obj);
     }
@@ -116,16 +118,8 @@ static PyObject* py_unmiximage(PyObject* self, PyObject* args) {
             return NULL;
         }
 
-        Py_DECREF(fractionsImage_obj);  // Drop reference to original Fortran array
+        Py_DECREF(fractionsImage_obj);  // Drop reference to original array
         fractionsImage_obj = temp;      // Assign the new one
-
-/*        fractionsImage_obj = (PyArrayObject*) PyArray_FromArray(fractionsImage_obj,
-                                                                  PyArray_DescrFromType(NPY_DOUBLE),
-                                                                  NPY_ARRAY_C_CONTIGUOUS);
-        if (!fractionsImage_obj) {
-            PyErr_SetString(PyExc_ValueError, "Failed to convert fractionsImage to C-contiguous.");
-            return NULL;
-        } */
     }
 
     return PyArray_Return(fractionsImage_obj);


### PR DESCRIPTION
Possible solution to [issue #59 ](https://github.com/GeoscienceAustralia/fc/issues/59).

1. Track our created reference to `image_obj` so it can be decremented once we are done with it. 
2. Decrement our reference to fractionsImage_obj before assigning it to a new object so it can be removed.