### PR TITLE
Publish manylinux wheels to pypi

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -5,9 +5,29 @@ on:
     types: [published]
 
 jobs:
-  publish_pypi:
-    if: github.repository == 'GeoscienceAustralia/fc'
+  build_wheels:
+    runs-on: ubuntu-latest
 
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v4.2.0
+        env:
+          CIBW_BUILD: "cp3{10,11,12,13}-manylinux_x86_64"
+          CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_28
+          CIBW_BEFORE_ALL_LINUX: |
+            yum install -y gcc-gfortran
+          CIBW_TEST_SKIP: "*"
+
+      - uses: actions/upload-artifact@v6
+        with:
+          name: wheels
+          path: wheelhouse/*.whl
+
+  publish:
+    if: github.repository == 'GeoscienceAustralia/fc'
+    needs: build_wheels
     runs-on: ubuntu-latest
 
     environment: pypi
@@ -16,33 +36,12 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/checkout@v4
-
-      - name: Setup Python
-        uses: actions/setup-python@v5
+      - uses: actions/download-artifact@v7
         with:
-          python-version: "3.10"
+          name: wheels
+          path: dist
 
-      - name: Install build dependencies
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip freeze
-
-      - name: Install wheel dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y gfortran
-          python -m pip install auditwheel
-
-      - name: Build manylinux wheel
-        run: |
-          python setup.py sdist bdist_wheel
-          auditwheel repair dist/*linux_x86_64.whl \
-            --plat manylinux_2_27_x86_64 \
-            --wheel-dir dist/
-          rm dist/*linux_x86_64.whl
-
-      - name: Publish to PyPI
+      - name: Publish to TestPyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           skip-existing: true


### PR DESCRIPTION
Builds `manylinux` wheels for python 3.10-3.13.
Does not do `sdist` yet.

Tested against test.pypi.org here, failed due to version number, which should be pass when released properly: see https://github.com/GeoscienceAustralia/fc/actions/runs/33848987924